### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "iofitness",
+  "install": "pnpm install --frozen-lockfile",
+  "ports": [
+    {
+      "name": "next-dev",
+      "port": 3000
+    }
+  ],
+  "terminals": [
+    {
+      "name": "next-dev",
+      "command": "pnpm dev",
+      "description": "Next.js dev server (App Router) on http://localhost:3000"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the `iofitness` Next.js marketing site by adding a repository-managed `.cursor/environment.json`. This makes the dev environment reproducible for future agents: dependencies are installed on boot and the Next.js dev server is launched automatically.

## What was added

`.cursor/environment.json`:
- `install`: `pnpm install --frozen-lockfile` (respects the committed `pnpm-lock.yaml` and pinned `packageManager` pnpm@10.33.3)
- `ports`: exposes port `3000`
- `terminals`: runs `pnpm dev` (Next.js App Router dev server) as a named, inspectable terminal

The default base image already provides Node 22 and pnpm, so no custom Dockerfile is required.

## Verification

- `pnpm install` — succeeds
- `pnpm lint` — passes (no issues)
- `pnpm typecheck` (`tsc --noEmit`) — passes
- `pnpm build` (`next build`, Next.js 16.3.4 / Turbopack) — compiles and prerenders all 10 routes successfully
- `pnpm dev` — serves the site; `/`, `/learn`, `/robots.txt`, `/sitemap.xml` all return HTTP 200
- Draft environment build off this branch: **SUCCEEDED**
- Manual browser walkthrough: homepage loads, marketing content renders, the early-access form submits and shows "You are on the list. We will be in touch.", and `/learn` renders its empty-state copy — no errors or broken layouts

[iofitness_dev_server_walkthrough.mp4](https://cursor.com/agents/bc-beb2301c-8ae0-4675-8f99-33a725d1cb55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fiofitness_dev_server_walkthrough.mp4)

[IOFitness homepage](https://cursor.com/agents/bc-beb2301c-8ae0-4675-8f99-33a725d1cb55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)

[Early access form success](https://cursor.com/agents/bc-beb2301c-8ae0-4675-8f99-33a725d1cb55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fearly_access_form_success.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-beb2301c-8ae0-4675-8f99-33a725d1cb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-beb2301c-8ae0-4675-8f99-33a725d1cb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

