### PR TITLE
Persist early-access signups in free Postgres (Neon)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,6 @@
 SITE_URL=https://io.fitness
 
 # Required for early-access form persistence (server-side only).
-# Create a Resend API key with Full access (Contacts + Contact Properties).
-RESEND_API_KEY=
-
-# Optional but recommended. Resend Segment ID for "IOFitness Early Access".
-# Contacts are created/updated even without this; with it, they are also
-# added to the segment for broadcasts.
-# RESEND_EARLY_ACCESS_SEGMENT_ID=
+# Use a Neon (or other Postgres) connection string. Prefer the pooled /
+# serverless URL on Vercel. Never expose this to the browser.
+DATABASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Canonical production origin. Used by metadata, sitemap, and robots.
 SITE_URL=https://io.fitness
 
-# Optional. If set, early-access signups are POSTed as JSON:
-# { "email": "...", "goal": "...", "receivedAt": "..." }
-# If unset, the form still validates and confirms on the page,
-# but signups are only written to server logs.
-# EARLY_ACCESS_WEBHOOK_URL=
+# Required for early-access form persistence (server-side only).
+# Create a Resend API key with Full access (Contacts + Contact Properties).
+RESEND_API_KEY=
+
+# Optional but recommended. Resend Segment ID for "IOFitness Early Access".
+# Contacts are created/updated even without this; with it, they are also
+# added to the segment for broadcasts.
+# RESEND_EARLY_ACCESS_SEGMENT_ID=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Marketing and content site for [IOFitness](https://io.fitness). This is not the 
 - TypeScript
 - Tailwind CSS
 - Server Components by default
-- Resend Contacts API for early-access signups
+- Postgres (Neon) for early-access signups
 
 ## Local development
 
@@ -33,14 +33,15 @@ npm run build
 
 ## Early access
 
-The homepage form validates an email address and an optional goal, then upserts a Resend contact via a server action.
+The homepage form validates an email address and an optional goal, then upserts a row in Postgres via a server action.
 
 Required environment variable:
 
-- `RESEND_API_KEY` — Resend API key with Full access (not send-only)
+- `DATABASE_URL` — Postgres connection string (Neon free tier works on Vercel)
 
-Optional environment variable:
+Schema:
 
-- `RESEND_EARLY_ACCESS_SEGMENT_ID` — Segment ID for an "IOFitness Early Access" segment in Resend
+- Table `early_access_signups` (`email` unique, optional `goal`, timestamps)
+- Created automatically on first signup; SQL is also in `sql/early-access.sql`
 
-Optional goal answers are stored on the contact as the `early_access_goal` custom property (created automatically on first use if missing).
+Re-submitting the same email updates the existing row (and refreshes `goal` when provided) instead of creating a duplicate.

--- a/README.md
+++ b/README.md
@@ -8,20 +8,21 @@ Marketing and content site for [IOFitness](https://io.fitness). This is not the 
 - TypeScript
 - Tailwind CSS
 - Server Components by default
+- Resend Contacts API for early-access signups
 
 ## Local development
 
 ```bash
-pnpm install
-pnpm dev
+npm install
+npm run dev
 ```
 
 ## Checks
 
 ```bash
-pnpm lint
-pnpm typecheck
-pnpm build
+npm run lint
+npm run typecheck
+npm run build
 ```
 
 ## Content
@@ -32,6 +33,14 @@ pnpm build
 
 ## Early access
 
-The homepage form validates an email address and an optional goal. Persistence is not connected yet.
+The homepage form validates an email address and an optional goal, then upserts a Resend contact via a server action.
 
-Set `EARLY_ACCESS_WEBHOOK_URL` to POST signups as JSON. Until that is set, submissions are logged only.
+Required environment variable:
+
+- `RESEND_API_KEY` — Resend API key with Full access (not send-only)
+
+Optional environment variable:
+
+- `RESEND_EARLY_ACCESS_SEGMENT_ID` — Segment ID for an "IOFitness Early Access" segment in Resend
+
+Optional goal answers are stored on the contact as the `early_access_goal` custom property (created automatically on first use if missing).

--- a/components/early-access-form.tsx
+++ b/components/early-access-form.tsx
@@ -78,7 +78,10 @@ export function EarlyAccessForm({ id = "early-access" }: EarlyAccessFormProps) {
           >
             {pending ? "Sending…" : copy.submit}
           </button>
+
+          <p className="text-xs leading-relaxed text-muted/80">{copy.consent}</p>
         </form>
+
       )}
     </div>
   );

--- a/content/homepage.ts
+++ b/content/homepage.ts
@@ -12,10 +12,13 @@ export const homepageCopy = {
     emailPlaceholder: "you@example.com",
     goalLabel: "What do you want to get better at?",
     goalPlaceholder: "Optional",
+    consent:
+      "We'll email you about IOFitness early access and product updates. Unsubscribe anytime.",
     success: "You are on the list. We will be in touch.",
     invalidEmail: "Please enter a valid email address.",
     error: "Something went wrong. Please try again.",
   },
+
   goals: {
     heading: "Goals are more complicated than simple categories",
     body: "Anyone who knows what they want their body to be capable of but doesn't know how to program the path there already has a goal. It is rarely one checkbox. Strength, endurance, skill, and the activities you care about usually sit together, and they do not move on the same schedule.",

--- a/lib/early-access.ts
+++ b/lib/early-access.ts
@@ -1,4 +1,4 @@
-import { Resend, type ErrorResponse } from "resend";
+import { neon, type NeonQueryFunction } from "@neondatabase/serverless";
 
 export type EarlyAccessSignup = {
   email: string;
@@ -7,9 +7,8 @@ export type EarlyAccessSignup = {
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const GOAL_PROPERTY_KEY = "early_access_goal";
 
-let goalPropertyReady: Promise<void> | null = null;
+let schemaReady: Promise<void> | null = null;
 
 export function isValidEmail(value: string): boolean {
   return EMAIL_PATTERN.test(value) && value.length <= 254;
@@ -30,174 +29,62 @@ export function parseEarlyAccessForm(formData: FormData): {
   };
 }
 
-function getResendClient(): Resend {
-  const apiKey = process.env.RESEND_API_KEY?.trim();
+function getSql(): NeonQueryFunction<false, false> {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
 
-  if (!apiKey) {
-    throw new Error("RESEND_API_KEY is not configured");
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not configured");
   }
 
-  return new Resend(apiKey);
+  return neon(databaseUrl);
 }
 
-function getEarlyAccessSegmentId(): string | undefined {
-  const segmentId = process.env.RESEND_EARLY_ACCESS_SEGMENT_ID?.trim();
-  return segmentId || undefined;
-}
-
-function logResendFailure(context: string, error: ErrorResponse): void {
-  console.error(`[early-access] ${context}`, {
-    name: error.name,
-    statusCode: error.statusCode,
-  });
-}
-
-function failPersistence(context: string, error: ErrorResponse): never {
-  logResendFailure(context, error);
-  throw new Error("Failed to persist early access signup");
-}
-
-function isNotFoundError(error: ErrorResponse | null | undefined): boolean {
-  return error?.name === "not_found" || error?.statusCode === 404;
-}
-
-function isConflictOrDuplicateError(
-  error: ErrorResponse | null | undefined,
-): boolean {
-  if (!error) {
-    return false;
-  }
-
-  if (error.statusCode === 409 || error.statusCode === 422) {
-    return true;
-  }
-
-  const message = error.message.toLowerCase();
-  return (
-    message.includes("already exists") ||
-    message.includes("already exist") ||
-    message.includes("already been") ||
-    message.includes("already a member") ||
-    message.includes("already in") ||
-    message.includes("duplicate")
-  );
-}
-
-async function ensureGoalProperty(resend: Resend): Promise<void> {
-  if (!goalPropertyReady) {
-    goalPropertyReady = (async () => {
-      const listed = await resend.contactProperties.list();
-
-      if (listed.error) {
-        failPersistence("list contact properties", listed.error);
-      }
-
-      const exists = listed.data.data.some(
-        (property) => property.key === GOAL_PROPERTY_KEY,
-      );
-
-      if (exists) {
-        return;
-      }
-
-      const created = await resend.contactProperties.create({
-        key: GOAL_PROPERTY_KEY,
-        type: "string",
-        fallbackValue: "",
-      });
-
-      if (created.error && !isConflictOrDuplicateError(created.error)) {
-        failPersistence("create contact property", created.error);
-      }
+async function ensureSchema(sql: NeonQueryFunction<false, false>): Promise<void> {
+  if (!schemaReady) {
+    schemaReady = (async () => {
+      await sql`
+        CREATE TABLE IF NOT EXISTS early_access_signups (
+          id BIGSERIAL PRIMARY KEY,
+          email TEXT NOT NULL UNIQUE,
+          goal TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+      `;
     })().catch((error) => {
-      goalPropertyReady = null;
+      schemaReady = null;
       throw error;
     });
   }
 
-  await goalPropertyReady;
-}
-
-async function updateExistingContact(
-  resend: Resend,
-  email: string,
-  goal: string | undefined,
-  segmentId: string | undefined,
-): Promise<void> {
-  if (goal) {
-    await ensureGoalProperty(resend);
-
-    const updated = await resend.contacts.update({
-      email,
-      properties: {
-        [GOAL_PROPERTY_KEY]: goal,
-      },
-    });
-
-    if (updated.error) {
-      failPersistence("update contact", updated.error);
-    }
-  }
-
-  if (segmentId) {
-    const added = await resend.contacts.segments.add({
-      email,
-      segmentId,
-    });
-
-    if (added.error && !isConflictOrDuplicateError(added.error)) {
-      failPersistence("add contact to segment", added.error);
-    }
-  }
+  await schemaReady;
 }
 
 export async function saveEarlyAccessSignup(
   signup: EarlyAccessSignup,
 ): Promise<{ persisted: boolean }> {
-  const resend = getResendClient();
-  const segmentId = getEarlyAccessSegmentId();
-  const properties = signup.goal
-    ? { [GOAL_PROPERTY_KEY]: signup.goal }
-    : undefined;
+  const sql = getSql();
 
-  if (properties) {
-    await ensureGoalProperty(resend);
-  }
+  try {
+    await ensureSchema(sql);
 
-  const existing = await resend.contacts.get({ email: signup.email });
-
-  if (existing.data) {
-    await updateExistingContact(
-      resend,
-      signup.email,
-      signup.goal,
-      segmentId,
-    );
-    return { persisted: true };
-  }
-
-  if (existing.error && !isNotFoundError(existing.error)) {
-    failPersistence("get contact", existing.error);
-  }
-
-  const created = await resend.contacts.create({
-    email: signup.email,
-    unsubscribed: false,
-    ...(properties ? { properties } : {}),
-    ...(segmentId ? { segments: [{ id: segmentId }] } : {}),
-  });
-
-  if (created.error) {
-    if (!isConflictOrDuplicateError(created.error)) {
-      failPersistence("create contact", created.error);
-    }
-
-    await updateExistingContact(
-      resend,
-      signup.email,
-      signup.goal,
-      segmentId,
-    );
+    await sql`
+      INSERT INTO early_access_signups (email, goal, created_at, updated_at)
+      VALUES (
+        ${signup.email},
+        ${signup.goal ?? null},
+        ${signup.receivedAt}::timestamptz,
+        ${signup.receivedAt}::timestamptz
+      )
+      ON CONFLICT (email) DO UPDATE SET
+        goal = COALESCE(EXCLUDED.goal, early_access_signups.goal),
+        updated_at = EXCLUDED.updated_at
+    `;
+  } catch (error) {
+    console.error("[early-access] database persistence failed", {
+      name: error instanceof Error ? error.name : "unknown",
+    });
+    throw new Error("Failed to persist early access signup");
   }
 
   return { persisted: true };

--- a/lib/early-access.ts
+++ b/lib/early-access.ts
@@ -1,3 +1,5 @@
+import { Resend, type ErrorResponse } from "resend";
+
 export type EarlyAccessSignup = {
   email: string;
   goal?: string;
@@ -5,6 +7,9 @@ export type EarlyAccessSignup = {
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const GOAL_PROPERTY_KEY = "early_access_goal";
+
+let goalPropertyReady: Promise<void> | null = null;
 
 export function isValidEmail(value: string): boolean {
   return EMAIL_PATTERN.test(value) && value.length <= 254;
@@ -25,30 +30,175 @@ export function parseEarlyAccessForm(formData: FormData): {
   };
 }
 
+function getResendClient(): Resend {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY is not configured");
+  }
+
+  return new Resend(apiKey);
+}
+
+function getEarlyAccessSegmentId(): string | undefined {
+  const segmentId = process.env.RESEND_EARLY_ACCESS_SEGMENT_ID?.trim();
+  return segmentId || undefined;
+}
+
+function logResendFailure(context: string, error: ErrorResponse): void {
+  console.error(`[early-access] ${context}`, {
+    name: error.name,
+    statusCode: error.statusCode,
+  });
+}
+
+function failPersistence(context: string, error: ErrorResponse): never {
+  logResendFailure(context, error);
+  throw new Error("Failed to persist early access signup");
+}
+
+function isNotFoundError(error: ErrorResponse | null | undefined): boolean {
+  return error?.name === "not_found" || error?.statusCode === 404;
+}
+
+function isConflictOrDuplicateError(
+  error: ErrorResponse | null | undefined,
+): boolean {
+  if (!error) {
+    return false;
+  }
+
+  if (error.statusCode === 409 || error.statusCode === 422) {
+    return true;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("already exists") ||
+    message.includes("already exist") ||
+    message.includes("already been") ||
+    message.includes("already a member") ||
+    message.includes("already in") ||
+    message.includes("duplicate")
+  );
+}
+
+async function ensureGoalProperty(resend: Resend): Promise<void> {
+  if (!goalPropertyReady) {
+    goalPropertyReady = (async () => {
+      const listed = await resend.contactProperties.list();
+
+      if (listed.error) {
+        failPersistence("list contact properties", listed.error);
+      }
+
+      const exists = listed.data.data.some(
+        (property) => property.key === GOAL_PROPERTY_KEY,
+      );
+
+      if (exists) {
+        return;
+      }
+
+      const created = await resend.contactProperties.create({
+        key: GOAL_PROPERTY_KEY,
+        type: "string",
+        fallbackValue: "",
+      });
+
+      if (created.error && !isConflictOrDuplicateError(created.error)) {
+        failPersistence("create contact property", created.error);
+      }
+    })().catch((error) => {
+      goalPropertyReady = null;
+      throw error;
+    });
+  }
+
+  await goalPropertyReady;
+}
+
+async function updateExistingContact(
+  resend: Resend,
+  email: string,
+  goal: string | undefined,
+  segmentId: string | undefined,
+): Promise<void> {
+  if (goal) {
+    await ensureGoalProperty(resend);
+
+    const updated = await resend.contacts.update({
+      email,
+      properties: {
+        [GOAL_PROPERTY_KEY]: goal,
+      },
+    });
+
+    if (updated.error) {
+      failPersistence("update contact", updated.error);
+    }
+  }
+
+  if (segmentId) {
+    const added = await resend.contacts.segments.add({
+      email,
+      segmentId,
+    });
+
+    if (added.error && !isConflictOrDuplicateError(added.error)) {
+      failPersistence("add contact to segment", added.error);
+    }
+  }
+}
+
 export async function saveEarlyAccessSignup(
   signup: EarlyAccessSignup,
 ): Promise<{ persisted: boolean }> {
-  const webhookUrl = process.env.EARLY_ACCESS_WEBHOOK_URL;
+  const resend = getResendClient();
+  const segmentId = getEarlyAccessSegmentId();
+  const properties = signup.goal
+    ? { [GOAL_PROPERTY_KEY]: signup.goal }
+    : undefined;
 
-  if (webhookUrl) {
-    const response = await fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(signup),
-    });
+  if (properties) {
+    await ensureGoalProperty(resend);
+  }
 
-    if (!response.ok) {
-      throw new Error(`Early access webhook failed with ${response.status}`);
-    }
+  const existing = await resend.contacts.get({ email: signup.email });
 
+  if (existing.data) {
+    await updateExistingContact(
+      resend,
+      signup.email,
+      signup.goal,
+      segmentId,
+    );
     return { persisted: true };
   }
 
-  console.info("[early-access] signup received, persistence not connected", {
+  if (existing.error && !isNotFoundError(existing.error)) {
+    failPersistence("get contact", existing.error);
+  }
+
+  const created = await resend.contacts.create({
     email: signup.email,
-    hasGoal: Boolean(signup.goal),
-    receivedAt: signup.receivedAt,
+    unsubscribed: false,
+    ...(properties ? { properties } : {}),
+    ...(segmentId ? { segments: [{ id: segmentId }] } : {}),
   });
 
-  return { persisted: false };
+  if (created.error) {
+    if (!isConflictOrDuplicateError(created.error)) {
+      failPersistence("create contact", created.error);
+    }
+
+    await updateExistingContact(
+      resend,
+      signup.email,
+      signup.goal,
+      segmentId,
+    );
+  }
+
+  return { persisted: true };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "iofitness",
       "version": "0.1.0",
       "dependencies": {
+        "@neondatabase/serverless": "^1.1.0",
         "next": "16.3.4",
         "react": "19.2.8",
-        "react-dom": "19.2.8",
-        "resend": "^6.25.0"
+        "react-dom": "19.2.8"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1096,6 +1096,15 @@
         "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.3.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
@@ -1326,12 +1335,6 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3685,12 +3688,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
-    },
     "node_modules/fastq": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
@@ -5544,12 +5541,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/postal-mime": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
-      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
-      "license": "MIT-0"
-    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -5702,27 +5693,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.25.0.tgz",
-      "integrity": "sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.5",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -6101,16 +6071,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "16.3.4",
         "react": "19.2.8",
-        "react-dom": "19.2.8"
+        "react-dom": "19.2.8",
+        "resend": "^6.25.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -23,7 +24,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1325,6 +1326,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3678,6 +3685,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
@@ -5531,6 +5544,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -5683,6 +5702,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.25.0.tgz",
+      "integrity": "sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -6061,6 +6101,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "next": "16.3.4",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "resend": "^6.25.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "vercel-build": "next build"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^1.1.0",
     "next": "16.3.4",
     "react": "19.2.8",
-    "react-dom": "19.2.8",
-    "resend": "^6.25.0"
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/sql/early-access.sql
+++ b/sql/early-access.sql
@@ -1,0 +1,11 @@
+-- Early-access signups for the IOFitness public site.
+-- Optional: run this once in the Neon SQL editor.
+-- The app also creates this table automatically on first signup.
+
+CREATE TABLE IF NOT EXISTS early_access_signups (
+  id BIGSERIAL PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  goal TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the Resend waitlist path with durable Postgres storage so the site can stay on free Vercel without paying for (or depending on) an email vendor yet.

- Server action upserts into `early_access_signups` via `DATABASE_URL`
- Email is unique; re-submits update the row and refresh optional `goal`
- Table is created automatically on first signup (`sql/early-access.sql` included)
- Consent copy under the submit button is unchanged
- No welcome email, double opt-in, or Resend dependency

## What you need to configure

### Neon (free)

1. Create a free Neon project
2. Copy the **pooled / serverless** connection string
3. Optional: run `sql/early-access.sql` in the Neon SQL editor (the app also auto-creates the table)

### Vercel (`io-fitness`)

Add:

- `DATABASE_URL` = your Neon connection string

Apply to Production (and Preview if you want preview form submissions to persist).

No Resend account, API key, segment, or DNS changes are required for capturing signups.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Note

PR #39 (Resend) is superseded by this approach and can be closed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13174b96-aef8-489f-8b03-af92d01be754?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13174b96-aef8-489f-8b03-af92d01be754&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

