### PR TITLE
Add Learn article: Progressive Overload Without Adding Weight

### DIFF
--- a/content/articles/progressive-overload-without-adding-weight.ts
+++ b/content/articles/progressive-overload-without-adding-weight.ts
@@ -1,0 +1,282 @@
+import type { LearnArticle } from "../learn";
+
+/**
+ * Authority article #4.
+ * Primary intent: progressive overload without adding weight
+ * Thesis: progressive overload means increasing the relevant stimulus as the
+ * athlete adapts; harder is not automatically better progression.
+ */
+export const progressiveOverloadArticle: LearnArticle = {
+  slug: "progressive-overload-without-adding-weight",
+  title:
+    "Progressive Overload Without Adding Weight: What Actually Counts as Progress?",
+  description:
+    "Progressive overload means increasing the relevant training stimulus over time. When you cannot add weight, the next lever depends on your goal, the exercise, and whether the work stays comparable.",
+  date: "2026-09-04",
+  dateModified: "2026-09-04",
+  body: [
+    {
+      type: "p",
+      text: "Progressive overload means increasing the relevant training stimulus over time as the athlete adapts. Adding weight is one way to do that. It is not the only way, and it is not always the right next step.",
+    },
+    {
+      type: "p",
+      text: "If the next dumbbell jump is too large, if the hotel gym tops out early, or if a heavier set ruins your range of motion, the useful question is not \"how do I make this harder somehow?\" It is \"what should progress next for the outcome I care about?\"",
+    },
+    {
+      type: "callout",
+      text: "Short version: when you cannot add weight, the cleanest next lever is usually more high-quality reps at the same load within an intended range. More sets, harder variations, longer ranges of motion, and other changes can also progress training, but only when they raise the relevant stimulus without destroying comparability. Making a set feel harder is not the same thing as useful progression.",
+    },
+
+    { type: "h2", text: "Progressive overload is not \"add weight every session\"" },
+    {
+      type: "p",
+      text: "A large share of fitness content treats progressive overload as a synonym for loading the bar. Another share corrects that with a menu: more reps, more sets, slower tempo, shorter rest, bigger range of motion, harder exercise variations, cleaner form. The second list is better than the first. It is still incomplete.",
+    },
+    {
+      type: "p",
+      text: "Those variables are not interchangeable. They change different demands. Some improve the quality you want. Some mainly change how miserable the set feels. Recent resistance-training evidence still treats progressive loading of the stimulus as fundamental, while also showing that many popular prescription details matter less than people assume, and matter differently by goal [1].",
+    },
+    {
+      type: "p",
+      text: "There is also a quieter problem with treating \"more total volume load\" as proof of progressive overload. Sets × reps × load can rise while the useful stimulus barely changes, or stay flat while the athlete clearly improves. External work totals are not a complete account of adaptation [2].",
+    },
+
+    { type: "h2", text: "Harder is not always better progression" },
+    {
+      type: "p",
+      text: "Useful progression raises the stimulus that matches the goal while keeping enough of the task comparable to judge what happened. Random difficulty is not that.",
+    },
+
+    { type: "h3", text: "Shorter rest" },
+    {
+      type: "p",
+      text: "Cutting rest makes a session denser. That can matter when work capacity or density is the target. It is a weaker default for strength or hypertrophy if the shorter rest forces lower force output or fewer quality reps. Current evidence does not show that shorter rests are a universal hypertrophy advantage; if anything, very short rests can make high-quality volume harder to maintain [3]. Shorter rest is a tool. It is not automatic progressive overload.",
+    },
+
+    { type: "h3", text: "Slower tempo" },
+    {
+      type: "p",
+      text: "A slower eccentric or a pause can make a set feel harder. That does not automatically make it a better strength or hypertrophy progression. Meta-analytic work on repetition duration found similar hypertrophy across a fairly wide tempo window, with very slow cadences looking worse when they force large load reductions [4]. Tempo can still be useful for control, standardized execution, or a specific technical goal. Chasing time under tension for its own sake is a different claim.",
+    },
+
+    { type: "h3", text: "Better form" },
+    {
+      type: "p",
+      text: "Cleaner technique can be real performance progress. Moving from a bouncing partial to a controlled full-range repetition can also change the task. Sometimes the honest label is not \"progressive overload.\" It is better execution of the intended stimulus. Both matter. They are not identical logbook events.",
+    },
+
+    { type: "h3", text: "Harder exercise variations" },
+    {
+      type: "p",
+      text: "A harder variation can solve an equipment limit. A bilateral squat, a split squat, and a rear-foot-elevated split squat are not the same exercise. Changing leverage can keep training productive when heavier dumbbells do not exist. It also reduces direct comparability with prior performance. Exercise progression needs a reason beyond novelty.",
+    },
+
+    { type: "h2", text: "Four reasons you may be unable to add weight" },
+
+    { type: "h3", text: "1. The next equipment jump is too large" },
+    {
+      type: "p",
+      text: "A 20 lb dumbbell to a 25 lb dumbbell is a 25% jump. For many upper-body accessories, that is not a small progression. It is a cliff. In that case, building reps inside the intended range, using microplates if they exist, or holding the current load until performance earns the jump is usually better than forcing a missed set and calling it toughness.",
+    },
+
+    { type: "h3", text: "2. Heavier equipment is simply unavailable" },
+    {
+      type: "p",
+      text: "Home gyms, hotel gyms, and bodyweight settings create a hard ceiling. Here the productive options are usually more quality reps, unilateral or longer-lever variations, fuller usable range of motion, and occasionally an extra productive set when recovery allows. The constraint is equipment. The response should still be goal-specific.",
+    },
+
+    { type: "h3", text: "3. You keep failing the heavier load" },
+    {
+      type: "p",
+      text: "That is different from lacking equipment. If the same progression target fails repeatedly under comparable conditions, inventing another way to make the same exercise feel harder may miss the point. The failure is information. The jump may be too large. Fatigue, weekly volume, frequency, technique, or an unrealistic progression rate may be the real limiter. This is where [adaptive training](/learn/what-is-adaptive-training) matters: the next prescription should respond to what actually happened.",
+    },
+
+    { type: "h3", text: "4. You can add weight, but doing so breaks the exercise" },
+    {
+      type: "p",
+      text: "If the heavier set shortens range of motion, changes the target muscle contribution, needs momentum, or collapses outside the intended rep range, the larger number may not be useful progress. The load should serve the training goal. Making the logbook look braver is not the goal.",
+    },
+
+    { type: "h2", text: "Repetition progression is often the cleanest next lever" },
+    {
+      type: "p",
+      text: "Double progression is a practical way to progress without forcing load every session. You work inside a rep range at a fixed load. When performance reaches the top of that range under comparable conditions, you increase load if an appropriate increment exists.",
+    },
+    {
+      type: "example",
+      title: "Example: 3 sets of 8-12 at 50 lb",
+      body: [
+        "Week 1: 50 lb for 10, 9, 8",
+        "Later: 50 lb for 12, 12, 12",
+        "Next jump: 55 lb for 9, 8, 8",
+      ],
+    },
+    {
+      type: "p",
+      text: "The athlete progressed substantially before the load changed. That pattern is especially useful when dumbbell jumps are large, small plates are missing, machine stacks move in coarse increments, or a 5 lb increase is a big percentage of the current load.",
+    },
+    {
+      type: "p",
+      text: "This is not just coach folklore. In resistance-trained adults, an 8-week comparison of load progression versus repetition progression found both approaches viable for muscular adaptations, with broadly similar hypertrophy and only small, practically uncertain differences in dynamic strength favoring load progression [5]. That does not prove one exact double-progression rule is optimal. It does support treating repetition progression as a legitimate overload strategy, especially when hypertrophy is the priority and load jumps are awkward.",
+    },
+
+    { type: "h2", text: "Which lever fits which goal?" },
+
+    { type: "h3", text: "Hypertrophy" },
+    {
+      type: "p",
+      text: "Current evidence suggests muscle growth can occur across a broad loading range when effort is high enough, with weekly volume mattering more than a narrow \"hypertrophy load zone\" [1]. So more high-quality reps at the same load, and eventually more load, are both coherent options. Extra sets can help when more productive volume is actually warranted and recoverable. Greater usable range of motion can matter if prior ROM was constrained. Harder leverage can help when external resistance is capped. None of that means every added rep forever is equally useful. Past a point, endless high-rep sets at a light load may stop being the best use of recovery.",
+    },
+
+    { type: "h3", text: "Maximal strength" },
+    {
+      type: "p",
+      text: "Load matters more here because the outcome itself is force against high external resistance. The ACSM overview found voluntary strength favored by heavier loads and complete range of motion, among other factors [1]. Adding reps at a light load can still build muscle or local endurance. It is usually not the most specific way to improve a 1RM. If strength is the goal and an appropriate heavier increment exists, loading should stay near the center of the progression plan.",
+    },
+
+    { type: "h3", text: "Power" },
+    {
+      type: "p",
+      text: "Do not progress power by making every set heavier, slower, and more fatiguing. Power work often progresses through output, movement quality, velocity, appropriate resistance, and more demanding but still explosive tasks. ACSM evidence favors moderate loads and fast concentric intent for power outcomes [1]. This article is not a full power program. The point is specificity: the lever has to match the adaptation.",
+    },
+
+    { type: "h3", text: "Muscular endurance" },
+    {
+      type: "p",
+      text: "More reps, longer unbroken work, and density are often closer to the target. A set that becomes harder only because rest was cut may be more relevant here than in a maximal-strength block. Match the lever to the quality you want.",
+    },
+
+    { type: "h2", text: "A practical progression hierarchy" },
+    {
+      type: "p",
+      text: "No single hierarchy is scientifically settled for every lifter. The sequence below is a practical decision framework for choosing the next progression when load is unavailable, inappropriate, or premature.",
+    },
+    {
+      type: "ol",
+      items: [
+        "Keep the exercise and execution standardized enough to compare sessions",
+        "Ask whether performance improved at the current load under those conditions",
+        "If the rep range still has room, add quality reps before changing other variables",
+        "When the top of the intended range is reached consistently, increase load if a sensible increment exists",
+        "If the increment is too large, use microloading or continue another legitimate same-exercise progression",
+        "Add sets only when more volume is useful and recoverable, not as a default boredom fix",
+        "Change exercise difficulty when equipment or exercise design requires it",
+        "If progression repeatedly stalls under comparable conditions, review the program instead of endlessly adding difficulty",
+      ],
+    },
+    {
+      type: "p",
+      text: "The hierarchy prefers comparability and goal fit over novelty. That is programming judgment informed by the evidence above, not a claim that one order is proven optimal for every outcome.",
+    },
+
+    { type: "h2", text: "Performance can improve before the prescription changes" },
+    {
+      type: "p",
+      text: "Suppose week 1 is 100 × 8 at a hard 9 RPE. Weeks later, the same prescription is 100 × 8 at about 7.5 RPE, with cleaner reps and no change in range of motion. The written program did not progress. The athlete may still have improved.",
+    },
+    {
+      type: "p",
+      text: "That distinction matters:",
+    },
+    {
+      type: "ul",
+      items: [
+        "Progress in adaptation: the same work costs less or produces a better result",
+        "Progression of prescription: the planned load, reps, sets, or exercise demand changes",
+      ],
+    },
+    {
+      type: "p",
+      text: "A good system notices the first before it forces the second. RPE and similar effort ratings are imperfect. They are still often enough to show that the same external work is no longer the same internal demand. Waiting for the bar to move every Monday can make people miss that kind of progress, or rush a load jump they have not earned under clean conditions.",
+    },
+
+    { type: "h2", text: "Do not reward bad comparability" },
+    {
+      type: "p",
+      text: "For progression to mean much, sessions need enough standardization to compare.",
+    },
+    {
+      type: "p",
+      text: "Ten controlled reps at 50 lb through a full range of motion are not automatically worse than twelve reps at 50 lb with a shortened range and momentum. Changing the machine, grip, exercise, range of motion, rest, and tempo all at once makes the log hard to interpret. If several variables move together, a \"PR\" may only mean the task changed. Change one main progression lever at a time unless there is a clear programming reason to renegotiate the whole exercise.",
+    },
+
+    { type: "h2", text: "When failure to progress means the program needs review" },
+    {
+      type: "p",
+      text: "Repeated failure under comparable conditions is not a cue to invent infinite new difficulty tricks. It is a cue to inspect the plan.",
+    },
+    {
+      type: "ul",
+      items: [
+        "Is the planned jump too large for this exercise?",
+        "Is weekly volume too high for the current recovery budget?",
+        "Did sleep, stress, illness, or a [missed training week](/learn/what-to-do-when-you-miss-a-workout) change readiness?",
+        "Is technique or range of motion drifting under the target load?",
+        "Is the goal mismatched to the progression method?",
+      ],
+    },
+    {
+      type: "p",
+      text: "Sometimes the answer is to stay at the current load and rebuild clean reps. Sometimes it is to reduce volume, change frequency, or pick a more appropriate exercise. The wrong answer is usually to keep stacking fatigue while calling every new discomfort \"overload.\"",
+    },
+
+    { type: "h2", text: "What adaptive programming should do" },
+    {
+      type: "p",
+      text: "Parameter adaptation is one of the simplest forms of [adaptive training](/learn/what-is-adaptive-training). A useful system does not add 5 lb every Monday forever. It observes completed performance, missed sessions, effort, and constraints, then chooses an appropriate next target: more reps, a small load increase, unchanged prescription after a hard week, or a different lever when equipment forces the issue.",
+    },
+    {
+      type: "p",
+      text: "IOFitness is being designed around that kind of decision. The programming model is intended to treat progression as evidence-driven parameter change, not as a fixed calendar of heavier weights. The framework in this article still works with a notebook if you keep the comparisons honest.",
+    },
+
+    { type: "h2", text: "Bottom line" },
+    {
+      type: "p",
+      text: "Progressive overload without adding weight is still progressive overload when the relevant stimulus rises over time. For many lifters, especially when equipment jumps are coarse and hypertrophy is the goal, more high-quality reps at the same load is the cleanest next step. Sets, range of motion, exercise leverage, and eventually load can all matter. Shorter rest and slower tempo mainly help when they serve the actual goal, not when they only make the set feel worse. Judge progress by comparable performance and goal fit. If the heavier option breaks the exercise, or if progression keeps failing for no clear equipment reason, review the program. Harder is easy. Useful progression takes more judgment.",
+    },
+  ],
+  sources: [
+    {
+      id: "1",
+      label: "ACSM 2026 resistance training position stand",
+      citation:
+        "Currier BS, D'Souza AC, Fiatarone Singh MA, Lowisz CV, Rawson ES, Schoenfeld BJ, Smith-Ryan AE, Steen JP, et al. Resistance Training Prescription for Muscle Function, Hypertrophy, and Physical Performance in Healthy Adults: An Overview of Reviews. Med Sci Sports Exerc. 2026;58(4):851-872. ACSM Position Stand.",
+      url: "https://doi.org/10.1249/mss.0000000000003897",
+      note: "Used for goal-specific prescription effects: heavier loads and full ROM favor voluntary strength; hypertrophy is supported across a wide load range with higher weekly volumes; power favors moderate loads and fast concentric intent; time under tension and several other popular levers show inconsistent effects. Progressive overload of the stimulus remains central.",
+    },
+    {
+      id: "2",
+      label: "Hammert total training volume progression critique",
+      citation:
+        "Hammert WB, Kataoka R, Yamada Y, Song JS, Kang A, Spitz RW, Loenneke JP. Progression of total training volume in resistance training studies and its application to skeletal muscle growth. Physiol Meas. 2024;45(8):08TR03.",
+      url: "https://doi.org/10.1088/1361-6579/ad7348",
+      note: "Argues that rising sets × reps × load is a measure of external work and does not reliably explain hypertrophy adaptations. Used to separate \"more volume load on paper\" from useful progressive overload.",
+    },
+    {
+      id: "3",
+      label: "Rest interval hypertrophy meta-analysis",
+      citation:
+        "Singer A, Wolf M, Generoso L, Arias E, Delcastillo K, Echevarria E, Martinez A, Androulakis Korakakis P, Refalo MC, Swinton PA, Schoenfeld BJ. Give it a rest: a systematic review with Bayesian meta-analysis on the effect of inter-set rest interval duration on muscle hypertrophy. Front Sports Act Living. 2024;6:1429789.",
+      url: "https://doi.org/10.3389/fspor.2024.1429789",
+      note: "Suggests a small hypertrophic benefit to rest intervals longer than about 60 seconds, possibly via better maintenance of volume load. Used against treating rest reduction as a universal overload lever.",
+    },
+    {
+      id: "4",
+      label: "Repetition duration hypertrophy meta-analysis",
+      citation:
+        "Schoenfeld BJ, Ogborn DI, Krieger JW. Effect of repetition duration during resistance training on muscle hypertrophy: a systematic review and meta-analysis. Sports Med. 2015;45(4):577-585.",
+      url: "https://doi.org/10.1007/s40279-015-0304-0",
+      note: "Found similar hypertrophy across repetition durations of roughly 0.5-8 seconds, with very slow tempos appearing inferior when they force large load reductions. Used to separate tempo as a control tool from tempo as automatic progressive overload.",
+    },
+    {
+      id: "5",
+      label: "Plotkin load versus repetition progression trial",
+      citation:
+        "Plotkin D, Coleman M, Van Every D, Maldonado J, Oberlin D, Israetel M, Feather J, Alto A, Vigotsky AD, Schoenfeld BJ. Progressive overload without progressing load? The effects of load or repetition progression on muscular adaptations. PeerJ. 2022;10:e14142.",
+      url: "https://doi.org/10.7717/peerj.14142",
+      note: "In trained adults over 8 weeks, load progression and repetition progression were both viable. Hypertrophy was broadly similar; dynamic strength slightly favored load progression with uncertain practical significance. Used as direct evidence that repetition progression can constitute progressive overload.",
+    },
+  ],
+};

--- a/content/articles/progressive-overload-without-adding-weight.ts
+++ b/content/articles/progressive-overload-without-adding-weight.ts
@@ -25,7 +25,7 @@ export const progressiveOverloadArticle: LearnArticle = {
     },
     {
       type: "callout",
-      text: "Short version: when you cannot add weight, the cleanest next lever is usually more high-quality reps at the same load within an intended range. More sets, harder variations, longer ranges of motion, and other changes can also progress training, but only when they raise the relevant stimulus without destroying comparability. Making a set feel harder is not the same thing as useful progression.",
+      text: "Short version: for many hypertrophy and general-strength exercises, especially when the next load jump is too large or external resistance is temporarily capped, adding high-quality reps within the intended range is often the cleanest next step. Maximal strength, power, and endurance work may need a different lever. More sets, harder variations, and other changes can also progress training, but only when they raise the relevant stimulus without destroying comparability. Making a set feel harder is not the same thing as useful progression.",
     },
 
     { type: "h2", text: "Progressive overload is not \"add weight every session\"" },
@@ -77,7 +77,7 @@ export const progressiveOverloadArticle: LearnArticle = {
     { type: "h3", text: "1. The next equipment jump is too large" },
     {
       type: "p",
-      text: "A 20 lb dumbbell to a 25 lb dumbbell is a 25% jump. For many upper-body accessories, that is not a small progression. It is a cliff. In that case, building reps inside the intended range, using microplates if they exist, or holding the current load until performance earns the jump is usually better than forcing a missed set and calling it toughness.",
+      text: "A 20 lb dumbbell to a 25 lb dumbbell is a 25% jump. For many upper-body accessories, that is not a small progression. It is a large relative increase. In that case, building reps inside the intended range, using microplates if they exist, or holding the current load until performance earns the jump is usually better than forcing a missed set.",
     },
 
     { type: "h3", text: "2. Heavier equipment is simply unavailable" },
@@ -95,13 +95,13 @@ export const progressiveOverloadArticle: LearnArticle = {
     { type: "h3", text: "4. You can add weight, but doing so breaks the exercise" },
     {
       type: "p",
-      text: "If the heavier set shortens range of motion, changes the target muscle contribution, needs momentum, or collapses outside the intended rep range, the larger number may not be useful progress. The load should serve the training goal. Making the logbook look braver is not the goal.",
+      text: "If the heavier set shortens range of motion, changes the target muscle contribution, needs momentum, or collapses outside the intended rep range, the larger number may not be useful progress. The load should serve the training goal, not merely increase the number written in the log.",
     },
 
-    { type: "h2", text: "Repetition progression is often the cleanest next lever" },
+    { type: "h2", text: "Repetition progression is often the cleanest next lever for hypertrophy and general-strength work" },
     {
       type: "p",
-      text: "Double progression is a practical way to progress without forcing load every session. You work inside a rep range at a fixed load. When performance reaches the top of that range under comparable conditions, you increase load if an appropriate increment exists.",
+      text: "Double progression is a practical way to progress without forcing load every session on hypertrophy and general-strength exercises. You work inside a rep range at a fixed load. When performance reaches the top of that range under comparable conditions, you increase load if an appropriate increment exists.",
     },
     {
       type: "example",
@@ -126,7 +126,7 @@ export const progressiveOverloadArticle: LearnArticle = {
     { type: "h3", text: "Hypertrophy" },
     {
       type: "p",
-      text: "Current evidence suggests muscle growth can occur across a broad loading range when effort is high enough, with weekly volume mattering more than a narrow \"hypertrophy load zone\" [1]. So more high-quality reps at the same load, and eventually more load, are both coherent options. Extra sets can help when more productive volume is actually warranted and recoverable. Greater usable range of motion can matter if prior ROM was constrained. Harder leverage can help when external resistance is capped. None of that means every added rep forever is equally useful. Past a point, endless high-rep sets at a light load may stop being the best use of recovery.",
+      text: "Current evidence suggests muscle growth can occur across a broad loading range when effort is high enough, with weekly volume mattering more than a narrow \"hypertrophy load zone\" [1]. So more high-quality reps at the same load, and eventually more load, are both coherent options. Extra sets can help when more productive volume is actually warranted and recoverable. Restoring the intended range of motion after it had shortened under load is better framed as cleaner execution of the planned stimulus than as a separate overload method. Harder leverage can help when external resistance is capped. None of that means every added rep forever is equally useful. Past a point, endless high-rep sets at a light load may stop being the best use of recovery.",
     },
 
     { type: "h3", text: "Maximal strength" },
@@ -147,10 +147,13 @@ export const progressiveOverloadArticle: LearnArticle = {
       text: "More reps, longer unbroken work, and density are often closer to the target. A set that becomes harder only because rest was cut may be more relevant here than in a maximal-strength block. Match the lever to the quality you want.",
     },
 
-    { type: "h2", text: "A practical progression hierarchy" },
+    {
+      type: "h2",
+      text: "A practical progression hierarchy for hypertrophy and general-strength work",
+    },
     {
       type: "p",
-      text: "No single hierarchy is scientifically settled for every lifter. The sequence below is a practical decision framework for choosing the next progression when load is unavailable, inappropriate, or premature.",
+      text: "No single hierarchy is scientifically settled for every lifter. The sequence below is a practical decision framework for rep-based resistance training when hypertrophy or general strength is the main goal, especially when load is unavailable, inappropriate, or premature.",
     },
     {
       type: "ol",
@@ -160,20 +163,20 @@ export const progressiveOverloadArticle: LearnArticle = {
         "If the rep range still has room, add quality reps before changing other variables",
         "When the top of the intended range is reached consistently, increase load if a sensible increment exists",
         "If the increment is too large, use microloading or continue another legitimate same-exercise progression",
-        "Add sets only when more volume is useful and recoverable, not as a default boredom fix",
+        "Add sets only when more volume is useful and recoverable",
         "Change exercise difficulty when equipment or exercise design requires it",
         "If progression repeatedly stalls under comparable conditions, review the program instead of endlessly adding difficulty",
       ],
     },
     {
       type: "p",
-      text: "The hierarchy prefers comparability and goal fit over novelty. That is programming judgment informed by the evidence above, not a claim that one order is proven optimal for every outcome.",
+      text: "This order is not universal. Maximal strength may prioritize load specificity sooner. Power may prioritize velocity, output, and movement quality. Muscular endurance may progress through reps, duration, or density. The hierarchy prefers comparability and goal fit over novelty. That is programming judgment informed by the evidence above, not a claim that one order is proven optimal for every outcome.",
     },
 
     { type: "h2", text: "Performance can improve before the prescription changes" },
     {
       type: "p",
-      text: "Suppose week 1 is 100 × 8 at a hard 9 RPE. Weeks later, the same prescription is 100 × 8 at about 7.5 RPE, with cleaner reps and no change in range of motion. The written program did not progress. The athlete may still have improved.",
+      text: "Suppose week 1 is 100 × 8 at a hard 9 RPE. Across later sessions, the same standardized prescription is repeatedly closer to 7.5 RPE under similar conditions, with cleaner reps and no change in range of motion. The written program did not progress. Capacity may still have improved.",
     },
     {
       type: "p",
@@ -182,13 +185,13 @@ export const progressiveOverloadArticle: LearnArticle = {
     {
       type: "ul",
       items: [
-        "Progress in adaptation: the same work costs less or produces a better result",
+        "Progress in capacity or performance: the same work costs less or produces a better result",
         "Progression of prescription: the planned load, reps, sets, or exercise demand changes",
       ],
     },
     {
       type: "p",
-      text: "A good system notices the first before it forces the second. RPE and similar effort ratings are imperfect. They are still often enough to show that the same external work is no longer the same internal demand. Waiting for the bar to move every Monday can make people miss that kind of progress, or rush a load jump they have not earned under clean conditions.",
+      text: "A good system notices the first before it forces the second. RPE is subjective. Sleep, stress, motivation, and familiarity can move it from day to day, so one easier session does not prove adaptation. If the same standardized work repeatedly feels easier under similar conditions, that can be evidence of improved capacity even before the prescription changes. Waiting for the bar to move every Monday can make people miss that kind of progress, or rush a load jump they have not earned under clean conditions.",
     },
 
     { type: "h2", text: "Do not reward bad comparability" },
@@ -234,7 +237,7 @@ export const progressiveOverloadArticle: LearnArticle = {
     { type: "h2", text: "Bottom line" },
     {
       type: "p",
-      text: "Progressive overload without adding weight is still progressive overload when the relevant stimulus rises over time. For many lifters, especially when equipment jumps are coarse and hypertrophy is the goal, more high-quality reps at the same load is the cleanest next step. Sets, range of motion, exercise leverage, and eventually load can all matter. Shorter rest and slower tempo mainly help when they serve the actual goal, not when they only make the set feel worse. Judge progress by comparable performance and goal fit. If the heavier option breaks the exercise, or if progression keeps failing for no clear equipment reason, review the program. Harder is easy. Useful progression takes more judgment.",
+      text: "Progressive overload without adding weight is still progressive overload when the relevant stimulus rises over time. For many hypertrophy and general-strength exercises, especially when equipment jumps are coarse, more high-quality reps at the same load is often the cleanest next step. Other goals may need a different lever sooner. Sets, exercise leverage, and eventually load can all matter. Shorter rest and slower tempo mainly help when they serve the actual goal, not when they only make the set feel worse. Judge progress by comparable performance and goal fit. If the heavier option breaks the exercise, or if progression keeps failing for no clear equipment reason, review the program. Useful progression depends on choosing the right lever, not on making every set feel harder.",
     },
   ],
   sources: [

--- a/content/articles/what-is-adaptive-training.ts
+++ b/content/articles/what-is-adaptive-training.ts
@@ -97,7 +97,7 @@ export const adaptiveTrainingArticle: LearnArticle = {
     { type: "h3", text: "Level 2: Parameter adaptation" },
     {
       type: "p",
-      text: "The basic structure stays familiar, but numbers change because of what the athlete actually did: load, pace, reps, intensity, or difficulty. Strength apps that raise weight after repeated successful sets, or endurance tools that recalibrate intensity from recent performance, often live here [2][6][7][8].",
+      text: "The basic structure stays familiar, but numbers change because of what the athlete actually did: load, pace, reps, intensity, or difficulty. Strength apps that raise weight after repeated successful sets, or endurance tools that recalibrate intensity from recent performance, often live here [2][6][7][8]. That is also where decisions like [progressive overload without adding weight](/learn/progressive-overload-without-adding-weight) live: more quality reps at the same load, a small jump when earned, or holding the prescription when conditions do not support a change.",
     },
 
     { type: "h3", text: "Level 3: Session adaptation" },

--- a/content/learn.ts
+++ b/content/learn.ts
@@ -1,4 +1,5 @@
 import { twoGoalsArticle } from "./articles/how-to-train-for-two-goals-at-once";
+import { progressiveOverloadArticle } from "./articles/progressive-overload-without-adding-weight";
 import { adaptiveTrainingArticle } from "./articles/what-is-adaptive-training";
 import { missedWorkoutArticle } from "./articles/what-to-do-when-you-miss-a-workout";
 
@@ -41,6 +42,7 @@ export const learnArticles: LearnArticle[] = [
   missedWorkoutArticle,
   twoGoalsArticle,
   adaptiveTrainingArticle,
+  progressiveOverloadArticle,
 ];
 
 export function getLearnArticles(): LearnArticle[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Learn authority article #4: **Progressive Overload Without Adding Weight: What Actually Counts as Progress?** (`/learn/progressive-overload-without-adding-weight`).

### Core contribution

Progressive overload means increasing the **relevant** training stimulus as the athlete adapts. Making a set harder is not automatically useful progression. The article separates:

- goal-fit progression levers
- random difficulty (short rest, slow tempo, novelty variations)
- progress in adaptation vs progression of prescription
- four distinct reasons someone “can’t add weight”

### Research base

- ACSM 2026 resistance-training position stand (Currier et al.)
- Plotkin et al. load vs repetition progression
- Hammert et al. on total volume-load progression
- Rest-interval and repetition-duration hypertrophy meta-analyses

### Wiring

- Registered in `content/learn.ts` (sitemap / Learn index / JSON-LD pick up automatically)
- Reciprocal link from adaptive-training Level 2 (parameter adaptation)
- Internal links to adaptive training and missed-workout articles

## Checks

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass (SSG includes new slug)

## Out of scope

- Article #5
- Merge / production IndexNow

Draft PR — do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f25f6092-90b3-45ec-b28a-4cd06a06c850?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f25f6092-90b3-45ec-b28a-4cd06a06c850&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

