### PR TITLE
Add Learn article: How to Return to Training After Time Off

### DIFF
--- a/content/articles/how-to-return-to-training-after-time-off.ts
+++ b/content/articles/how-to-return-to-training-after-time-off.ts
@@ -1,0 +1,275 @@
+import type { LearnArticle } from "../learn";
+
+/**
+ * Authority article #5.
+ * Primary intent: how to return to training after time off
+ * Thesis: re-entry should scale uncertain capacity with evidence from early
+ * sessions, not resume the old plan or reset to zero with a universal percentage.
+ */
+export const returnToTrainingArticle: LearnArticle = {
+  slug: "how-to-return-to-training-after-time-off",
+  title: "How to Return to Training After Time Off",
+  description:
+    "After a training break, treat your old program as useful history rather than today's prescription. Scale load, volume, frequency, and exercise complexity independently, then let the first sessions update the ramp.",
+  date: "2026-09-04",
+  dateModified: "2026-09-04",
+  body: [
+    {
+      type: "p",
+      text: "After time off, your previous program is useful history. It is not automatically your current prescription. A good return keeps enough familiarity to compare, reduces the parts of training stress that are most uncertain, and uses the first sessions to gather evidence before the plan ramps back up.",
+    },
+    {
+      type: "p",
+      text: "That is different from both common defaults. One default resumes last month's weights and weekly schedule as if nothing changed. The other treats every layoff as a full beginner restart with a fixed percentage cut. Neither matches how capacity actually returns.",
+    },
+    {
+      type: "callout",
+      text: "Short version: preserve familiar exercises and enough load to keep the work recognizable, be more conservative with hard-set volume and weekly frequency at first, avoid stacking novelty into week one, and let performance and recovery from the first sessions decide what increases next. Do not use one universal percentage for every break.",
+    },
+
+    { type: "h2", text: "Not every interruption is the same problem" },
+    {
+      type: "p",
+      text: "This article is mainly about ordinary training interruptions: travel, work, family, schedule chaos, lost motivation, or a stretch where lifting simply did not happen.",
+    },
+    {
+      type: "p",
+      text: "Illness-related time off can leave residual systemic effects that go beyond detraining. Injury-related time off is not only a detraining problem; the limiting tissue or movement may have its own capacity constraints. The framework below applies once you are actually ready to resume the relevant training. It cannot decide medical readiness.",
+    },
+
+    { type: "h2", text: "Your old program is history, not today's dose" },
+    {
+      type: "p",
+      text: "A missed workout and six weeks away sit on the same spectrum. Both require comparing planned training state with actual training state. After one miss, uncertainty is usually local. After a longer break, uncertainty about current capacity becomes much larger. That is why [what to do when you miss a workout](/learn/what-to-do-when-you-miss-a-workout) and a full re-entry plan share logic but not scale.",
+    },
+    {
+      type: "p",
+      text: "You already know useful things: exercise history, prior loads, prior volume, training age, and goals. You do not yet know current capacity, current tolerance for the old number of hard sets, or how quickly recovery will normalize. Preserve what is known. Temporarily reduce what is uncertain.",
+    },
+
+    { type: "h2", text: "What changes during time off" },
+    {
+      type: "p",
+      text: "Training adaptations reverse at different rates. Foundational detraining reviews show that strength performance is often relatively durable across short interruptions, while other qualities can drift sooner, and longer stoppages produce larger losses [1][2]. A 2013 meta-analysis of training cessation found that muscular performance declines with longer time away, with the size of the effect depending on the outcome and population [2].",
+    },
+    {
+      type: "p",
+      text: "That does not create one universal calendar where every quality drops on day 14. It does support a practical distinction: short interruptions often leave much of the old structure usable, while longer interruptions make old numbers historical reference rather than current targets.",
+    },
+    {
+      type: "p",
+      text: "Recent work also shows that a planned training break is not automatically catastrophic for long-term progress. In previously untrained adults, two 10-week resistance-training blocks separated by 10 weeks off produced similar final strength and muscle-size outcomes to 20 weeks of continuous training, because losses during the break were regained quickly during retraining [3]. That supports urgency about returning, not panic about one interruption erasing the whole training history.",
+    },
+
+    { type: "h2", text: "Why retained strength can fool you" },
+    {
+      type: "p",
+      text: "A person can feel surprisingly strong in the first workout back and still be poorly prepared for the old amount of hard work.",
+    },
+    {
+      type: "p",
+      text: "Strength on a familiar lift can remain relatively high after a break while tolerance for the previous set volume, weekly frequency, repeated hard sessions, conditioning load, or high eccentric exposure has fallen. That is one reason \"I can still lift it\" does not mean \"I should immediately resume the old program.\" The load you can move and the dose you can recover from are related. They are not identical.",
+    },
+    {
+      type: "p",
+      text: "This is programming inference built on the broader detraining pattern that force qualities and training tolerance do not reverse on one schedule [1][2]. It is not a claim that every athlete keeps a fixed percentage of their old 1RM after a fixed number of weeks.",
+    },
+
+    { type: "h2", text: "Scale four variables independently" },
+    {
+      type: "p",
+      text: "A universal \"come back at 50%\" rule fails because 50% of old load, 50% of old volume, and 50% of old weekly training stress are different prescriptions. After a break, those levers can move separately.",
+    },
+
+    { type: "h3", text: "1. Load / intensity" },
+    {
+      type: "p",
+      text: "Do not automatically slash load if the movement still feels familiar and early sets show substantial capacity. Old working weights are also not owed to you. Choose load from current performance under the intended execution. Autoregulated effort ratings can help here as rough guides, not as perfect sensors [4][5].",
+    },
+
+    { type: "h3", text: "2. Volume" },
+    {
+      type: "p",
+      text: "Hard-set volume is often the best place to be conservative at first. Someone may still handle a recognizable weight while no longer being accustomed to four hard working sets. Keeping a familiar load with fewer working sets is often cleaner than cutting the weight in half and still doing the old amount of hard work.",
+    },
+
+    { type: "h3", text: "3. Frequency" },
+    {
+      type: "p",
+      text: "Returning immediately to five demanding days because the old plan had five days can stack fatigue before you know how the first exposures land. Frequency can rebuild after per-session dose is tolerable again.",
+    },
+
+    { type: "h3", text: "4. Exercise complexity / novelty" },
+    {
+      type: "p",
+      text: "Familiar exercises help because technique history exists, old performance gives a reference point, and comparison is easier. Filling week one with several new movements makes it harder to tell whether soreness and fatigue reflect the layoff, the novelty, or both. Keep the early template comparable. That same comparability principle shows up in [progressive overload without adding weight](/learn/progressive-overload-without-adding-weight).",
+    },
+
+    { type: "h2", text: "The first sessions are training and evidence" },
+    {
+      type: "p",
+      text: "The first session back should still train you. It does not need to find a new 1RM. It should answer enough questions to update the next sessions:",
+    },
+    {
+      type: "ul",
+      items: [
+        "Does the movement still feel familiar?",
+        "What load can be performed with the intended execution?",
+        "How many clean reps are available?",
+        "How hard does the prescription feel relative to expectation?",
+        "How do you feel over the next day or two?",
+        "Does soreness interfere with normal movement or the next planned session?",
+      ],
+    },
+    {
+      type: "p",
+      text: "Soreness is not a goal and not a reliable measure of workout quality. Excessive or lingering soreness can still be useful feedback that the first dose exceeded current tolerance. Use it as one signal among others. Do not progress simply because you are not sore, and do not panic because you are.",
+    },
+
+    { type: "h2", text: "A worked re-entry example" },
+    {
+      type: "p",
+      text: "Before a six-week break, an athlete trained four days per week for hypertrophy and general strength: two lower and two upper sessions. Main lifts included squat 3 × 8 at 185 lb and bench 3 × 8 at 135 lb.",
+    },
+    {
+      type: "example",
+      title: "Plausible first week back",
+      body: [
+        "Keep the same main exercises rather than rebuilding the whole template",
+        "Train three days instead of four",
+        "Use warm-up sets to find a challenging but controlled working weight; do not assume 185 and 135 are still correct",
+        "Start with 2 working sets on the main lifts instead of 3",
+        "Keep accessories simple and familiar",
+        "Leave one recovery day between lower-body exposures",
+      ],
+    },
+    {
+      type: "p",
+      text: "Those numbers are an illustration of logic, not a scientifically prescribed comeback dose. The point is what gets protected and what gets reduced: familiarity and enough load to keep the work informative, with less weekly frequency and fewer hard sets until current tolerance is clearer.",
+    },
+
+    { type: "h3", text: "Response A: the first week lands cleanly" },
+    {
+      type: "p",
+      text: "Loads moved well, effort matched expectation, and moderate soreness settled before the next similar exposure. Week two can increase something modestly: a third working set on one main lift, a small load increase where reps were clearly available, or a return toward four sessions if recovery stayed clean. Increase one main variable at a time so the next evidence remains readable.",
+    },
+
+    { type: "h3", text: "Response B: the first week overshoots" },
+    {
+      type: "p",
+      text: "Effort was unexpectedly high, performance dropped across the week, or soreness still interfered with the next planned session. Week two should hold or reduce rather than follow a predetermined ramp. That may mean keeping three days, staying at two working sets, or lowering the working weight that forced form changes. A fixed four-week comeback calendar cannot see that signal. An adaptive one can.",
+    },
+
+    { type: "h2", text: "Short, moderate, and long interruptions" },
+    {
+      type: "p",
+      text: "Exact week cutoffs are less useful than categories, because training age, the quality lost, and the reason for the break all matter.",
+    },
+    {
+      type: "ul",
+      items: [
+        "Short interruption: much of the old structure may still fit. Confirm load with warm-ups, keep most of the template, and watch the first hard sessions before adding extra volume.",
+        "Moderate interruption: the old program remains useful history, but volume and frequency usually need revalidation even if strength on familiar lifts still looks decent.",
+        "Long interruption: treat old numbers as reference points, not current prescriptions. Rebuild with familiar movements, conservative hard-set volume, and a slower return of weekly density.",
+      ],
+    },
+    {
+      type: "p",
+      text: "These categories are programming judgment informed by the pattern that longer cessation tends to cost more performance [1][2], not a claim that every athlete crosses the same threshold on the same day.",
+    },
+
+    { type: "h2", text: "How prior training changes the return" },
+    {
+      type: "p",
+      text: "Someone who trained consistently for years and stopped for six weeks is not the same problem as someone who completed a handful of beginner sessions last year. Previous resistance training can leave retained adaptations that make later retraining more efficient than building the quality the first time [6][7]. In the periodic-training study above, strength and muscle size lost during a 10-week break returned rapidly once training resumed [3]. Proteomic work from the same project found that some training-related protein changes remained elevated even after the break, which is one biological candidate for that retained responsiveness [7].",
+    },
+    {
+      type: "p",
+      text: "That is the useful meaning of muscle memory here. It is not a promise that you will regain everything twice as fast, or that nothing was lost. Previous training changes the starting information available to the program and may allow lost adaptations to return faster than they were originally built. The magnitude and timeline are not universal [6].",
+    },
+
+    { type: "h2", text: "When normal progression resumes" },
+    {
+      type: "p",
+      text: "Once early sessions show that familiar work is tolerable again, ordinary progression logic returns: add quality reps, restore sets, restore frequency, then push load when the evidence supports it. That is the same decision process described in [progressive overload without adding weight](/learn/progressive-overload-without-adding-weight).",
+    },
+    {
+      type: "p",
+      text: "Early retraining may move faster than ordinary long-term progression because the athlete is regaining prior capacity rather than building it from scratch [3][6]. That does not mean old PRs are immediately available, and it does not mean the athlete should be forced onto a beginner linear plan simply because there was a break. Let the current log decide.",
+    },
+
+    { type: "h2", text: "What adaptive programming should do" },
+    {
+      type: "p",
+      text: "Returning after time off is a clear case for [adaptive training](/learn/what-is-adaptive-training). The system has historical training state, a meaningful interruption, uncertainty about current capacity, and new evidence arriving session by session. A static plan either resumes where it stopped or starts an arbitrary comeback template. An adaptive plan can keep familiar structure, reduce uncertain dose, and update the next week from what the first exposures actually produced.",
+    },
+    {
+      type: "p",
+      text: "IOFitness is being designed around that kind of re-entry. The intended model treats the old program as prior information, uses the first return sessions to re-estimate current capacity, and rebuilds volume, intensity, frequency, and complexity from the response rather than from a fixed percentage schedule.",
+    },
+
+    { type: "h2", text: "Bottom line" },
+    {
+      type: "p",
+      text: "Coming back after time off is not a choice between pretending nothing changed and starting from zero. Keep enough of the old plan to stay comparable. Reduce the variables that are most uncertain, especially hard-set volume and weekly density. Use the first sessions as both training and evidence. Then progress from the response. Prior training history may help you regain capacity faster than you built it the first time, but it does not hand you your old working weights on day one. The return should be scaled and evidence-driven.",
+    },
+  ],
+  sources: [
+    {
+      id: "1",
+      label: "Mujika and Padilla detraining review",
+      citation:
+        "Mujika I, Padilla S. Muscular characteristics of detraining in humans. Med Sci Sports Exerc. 2001;33(8):1297-1303.",
+      url: "https://doi.org/10.1097/00005768-200108000-00009",
+      note: "Foundational review of muscular changes during training cessation. Used for the broad pattern that strength can be relatively durable across short interruptions while other qualities and longer stoppages show larger losses. Not used as a universal week-by-week decay chart.",
+    },
+    {
+      id: "2",
+      label: "Bosquet training-cessation meta-analysis",
+      citation:
+        "Bosquet L, Berryman N, Dupuy O, Mekary S, Arvisais D, Bherer L, Mujika I. Effect of training cessation on muscular performance: a meta-analysis. Scand J Med Sci Sports. 2013;23(3):e140-e149.",
+      url: "https://doi.org/10.1111/sms.12047",
+      note: "Meta-analysis showing muscular performance declines with training cessation, with effect sizes depending on outcome and context. Used to support longer interruptions creating more uncertainty without assigning one universal percentage loss.",
+    },
+    {
+      id: "3",
+      label: "Halonen periodic versus continuous resistance training",
+      citation:
+        "Halonen EJ, Gabriel I, Kelahaara MM, Ahtiainen JP, Hulmi JJ. Does taking a break matter—adaptations in muscle strength and size between continuous and periodic resistance training. Scand J Med Sci Sports. 2024;34(10):e14739.",
+      url: "https://doi.org/10.1111/sms.14739",
+      note: "In previously untrained adults, 10 weeks on, 10 weeks off, 10 weeks on produced similar final strength and hypertrophy outcomes to 20 weeks continuous training because detraining losses were regained quickly. Used as evidence that re-gains can be rapid after a break, not as a prescription to take planned layoffs.",
+    },
+    {
+      id: "4",
+      label: "Greig autoregulation review",
+      citation:
+        "Greig L, Stephens Hemingway BH, Aspe RR, Cooper K, Comfort P, Swinton PA. Autoregulation in resistance training: addressing the inconsistencies. Sports Med. 2020;50(11):1873-1887.",
+      url: "https://doi.org/10.1007/s40279-020-01330-8",
+      note: "Supports adjusting training from measured performance or perceived capability across timescales. Used for the idea that early return sessions can inform later dose, not as proof that one RPE scale is perfectly reliable.",
+    },
+    {
+      id: "5",
+      label: "Helms RIR-based RPE",
+      citation:
+        "Helms ER, Cronin J, Storey A, Zourdos MC. Application of the repetitions in reserve-based rating of perceived exertion scale for resistance training. Strength Cond J. 2016;38(4):42-49.",
+      url: "https://doi.org/10.1519/SSC.0000000000000218",
+      note: "Practical reference for effort-based autoregulation. Used as one way to interpret early-session difficulty during re-entry, with the usual caveat that subjective ratings vary.",
+    },
+    {
+      id: "6",
+      label: "Sharples and Turner skeletal muscle memory review",
+      citation:
+        "Sharples AP, Turner DC. Skeletal muscle memory. Am J Physiol Cell Physiol. 2023;324(6):C1274-C1294.",
+      url: "https://doi.org/10.1152/ajpcell.00099.2023",
+      note: "Reviews cellular and epigenetic accounts of skeletal muscle memory and their implications for later retraining. Used to support retained responsiveness after prior training without claiming a universal regain-speed multiplier.",
+    },
+    {
+      id: "7",
+      label: "Hulmi proteomic muscle memory study",
+      citation:
+        "Hulmi JJ, Halonen EJ, Sharples AP, O'Connell TM, Kuikka L, Lappi VM, Salokas K, Keskitalo S, Varjosalo M, Ahtiainen JP. Human skeletal muscle possesses both reversible proteomic signatures and a retained proteomic memory after repeated resistance training. J Physiol. 2025;603(9):2655-2673.",
+      url: "https://doi.org/10.1113/JP288104",
+      note: "Shows that some resistance-training-related protein changes remain elevated after a multi-week training break, while many others reverse and rise again with retraining. Used as mechanistic support for retained training history, not as a consumer guarantee of faster progress.",
+    },
+  ],
+};

--- a/content/articles/how-to-return-to-training-after-time-off.ts
+++ b/content/articles/how-to-return-to-training-after-time-off.ts
@@ -12,7 +12,7 @@ export const returnToTrainingArticle: LearnArticle = {
   description:
     "After a training break, treat your old program as useful history rather than today's prescription. Scale load, volume, frequency, and exercise complexity independently, then let the first sessions update the ramp.",
   date: "2026-09-04",
-  dateModified: "2026-09-04",
+  dateModified: "2026-09-04", // revised evidence framing same day as publish draft
   body: [
     {
       type: "p",
@@ -20,7 +20,7 @@ export const returnToTrainingArticle: LearnArticle = {
     },
     {
       type: "p",
-      text: "That is different from both common defaults. One default resumes last month's weights and weekly schedule as if nothing changed. The other treats every layoff as a full beginner restart with a fixed percentage cut. Neither matches how capacity actually returns.",
+      text: "That is different from both common defaults. One default resumes last month's weights and weekly schedule as if nothing changed. The other treats every layoff as starting over from scratch with a fixed percentage cut. Neither matches how capacity actually returns.",
     },
     {
       type: "callout",
@@ -30,7 +30,7 @@ export const returnToTrainingArticle: LearnArticle = {
     { type: "h2", text: "Not every interruption is the same problem" },
     {
       type: "p",
-      text: "This article is mainly about ordinary training interruptions: travel, work, family, schedule chaos, lost motivation, or a stretch where lifting simply did not happen.",
+      text: "This article is mainly about ordinary training interruptions: travel, work, family, a crowded schedule, lost motivation, or a stretch where lifting simply did not happen.",
     },
     {
       type: "p",
@@ -58,7 +58,7 @@ export const returnToTrainingArticle: LearnArticle = {
     },
     {
       type: "p",
-      text: "Recent work also shows that a planned training break is not automatically catastrophic for long-term progress. In previously untrained adults, two 10-week resistance-training blocks separated by 10 weeks off produced similar final strength and muscle-size outcomes to 20 weeks of continuous training, because losses during the break were regained quickly during retraining [3]. That supports urgency about returning, not panic about one interruption erasing the whole training history.",
+      text: "Recent work also shows that a substantial break need not erase the ability to regain what was lost. In previously untrained adults who completed an initial supervised 10-week training block, a 10-week break, then another 10 weeks of training, final strength and muscle-size outcomes were similar to 20 weeks of continuous training because losses during the break were regained during retraining [3]. The useful takeaway is that a substantial break did not erase the participants' ability to regain prior adaptations once training resumed. That finding belongs to that population and protocol; it should not be treated as a universal result for trained athletes or every break length.",
     },
 
     { type: "h2", text: "Why retained strength can fool you" },
@@ -84,13 +84,13 @@ export const returnToTrainingArticle: LearnArticle = {
     { type: "h3", text: "1. Load / intensity" },
     {
       type: "p",
-      text: "Do not automatically slash load if the movement still feels familiar and early sets show substantial capacity. Old working weights are also not owed to you. Choose load from current performance under the intended execution. Autoregulated effort ratings can help here as rough guides, not as perfect sensors [4][5].",
+      text: "Do not automatically slash load if the movement still feels familiar and early sets show substantial capacity. Previous working weights are reference points, not guaranteed starting loads. Choose load from current performance under the intended execution. Autoregulated effort ratings can help here as rough guides, not as perfect sensors [4][5].",
     },
 
     { type: "h3", text: "2. Volume" },
     {
       type: "p",
-      text: "Hard-set volume is often the best place to be conservative at first. Someone may still handle a recognizable weight while no longer being accustomed to four hard working sets. Keeping a familiar load with fewer working sets is often cleaner than cutting the weight in half and still doing the old amount of hard work.",
+      text: "A practical programming default is to be conservative with hard-set volume at first, particularly when familiar loads still move well. Someone may still handle a recognizable weight while no longer being accustomed to four hard working sets. Keeping a familiar load with fewer working sets is often cleaner than cutting the weight in half and still doing the old amount of hard work. This is a re-entry heuristic, not a universally tested ordering of which variable must be reduced first. The detraining literature cited here did not randomize returners to load-first versus volume-first versus frequency-first cuts.",
     },
 
     { type: "h3", text: "3. Frequency" },
@@ -181,11 +181,15 @@ export const returnToTrainingArticle: LearnArticle = {
     { type: "h2", text: "How prior training changes the return" },
     {
       type: "p",
-      text: "Someone who trained consistently for years and stopped for six weeks is not the same problem as someone who completed a handful of beginner sessions last year. Previous resistance training can leave retained adaptations that make later retraining more efficient than building the quality the first time [6][7]. In the periodic-training study above, strength and muscle size lost during a 10-week break returned rapidly once training resumed [3]. Proteomic work from the same project found that some training-related protein changes remained elevated even after the break, which is one biological candidate for that retained responsiveness [7].",
+      text: "Someone who trained consistently for years and stopped for six weeks is not the same problem as someone who completed a handful of beginner sessions last year. Previous training can make lost adaptations return rapidly during retraining. In Halonen et al., previously untrained adults regained the measured strength and muscle-size losses from a 10-week break within about five weeks of retraining [3]. That does not prove retraining is universally faster than the original acquisition of those adaptations. In that study, the first five weeks of retraining were not faster than the participants' original first five weeks of training. The authors also could not determine whether any advantage relative to the later phase of continuous training reflected muscle memory or resensitization after the break [3].",
     },
     {
       type: "p",
-      text: "That is the useful meaning of muscle memory here. It is not a promise that you will regain everything twice as fast, or that nothing was lost. Previous training changes the starting information available to the program and may allow lost adaptations to return faster than they were originally built. The magnitude and timeline are not universal [6].",
+      text: "Proteomic work from the same project found that many training-induced protein changes reversed during detraining, while some remained altered after the break [7]. That provides evidence that prior training leaves a molecular trace after detraining. Whether those retained protein changes directly explain faster reacquisition of strength or muscle is not established.",
+    },
+    {
+      type: "p",
+      text: "Muscle-memory research provides plausible biological mechanisms for retained training history, but the size and practical effect of that memory vary and are not yet a universal programming rule [6][7]. The useful meaning here is simpler: previous training changes the starting information available to the program, and lost adaptations can return rapidly once training resumes. It is not a promise that you will regain everything twice as fast, or that nothing was lost.",
     },
 
     { type: "h2", text: "When normal progression resumes" },
@@ -195,7 +199,7 @@ export const returnToTrainingArticle: LearnArticle = {
     },
     {
       type: "p",
-      text: "Early retraining may move faster than ordinary long-term progression because the athlete is regaining prior capacity rather than building it from scratch [3][6]. That does not mean old PRs are immediately available, and it does not mean the athlete should be forced onto a beginner linear plan simply because there was a break. Let the current log decide.",
+      text: "Early retraining can produce rapid gains as prior capacity is reacquired [3]. That means the appropriate ramp may accelerate if repeated sessions show that load, volume, and frequency are being tolerated well. It does not mean the athlete should assume an automatic regain rate, and it does not mean old PRs are immediately available. Do not force a beginner linear plan simply because there was a break. Let the current log decide.",
     },
 
     { type: "h2", text: "What adaptive programming should do" },
@@ -211,7 +215,7 @@ export const returnToTrainingArticle: LearnArticle = {
     { type: "h2", text: "Bottom line" },
     {
       type: "p",
-      text: "Coming back after time off is not a choice between pretending nothing changed and starting from zero. Keep enough of the old plan to stay comparable. Reduce the variables that are most uncertain, especially hard-set volume and weekly density. Use the first sessions as both training and evidence. Then progress from the response. Prior training history may help you regain capacity faster than you built it the first time, but it does not hand you your old working weights on day one. The return should be scaled and evidence-driven.",
+      text: "Coming back after time off is not a choice between pretending nothing changed and starting from zero. Keep enough of the old plan to stay comparable. Reduce the variables that are most uncertain, especially hard-set volume and weekly density. Use the first sessions as both training and evidence. Then progress from the response. Prior training history can support rapid regain of lost adaptations, but it does not hand you your old working weights on day one or guarantee a faster ramp than your original progress. The return should be scaled and evidence-driven.",
     },
   ],
   sources: [
@@ -237,7 +241,7 @@ export const returnToTrainingArticle: LearnArticle = {
       citation:
         "Halonen EJ, Gabriel I, Kelahaara MM, Ahtiainen JP, Hulmi JJ. Does taking a break matter—adaptations in muscle strength and size between continuous and periodic resistance training. Scand J Med Sci Sports. 2024;34(10):e14739.",
       url: "https://doi.org/10.1111/sms.14739",
-      note: "In previously untrained adults, 10 weeks on, 10 weeks off, 10 weeks on produced similar final strength and hypertrophy outcomes to 20 weeks continuous training because detraining losses were regained quickly. Used as evidence that re-gains can be rapid after a break, not as a prescription to take planned layoffs.",
+      note: "In previously untrained adults, 10 weeks on, 10 weeks off, 10 weeks on produced similar final strength and hypertrophy outcomes to 20 weeks continuous training because detraining losses were regained during retraining (about five weeks back to prior post-training levels). First five weeks of retraining were not faster than original first five weeks; authors could not separate muscle memory from resensitization versus later continuous-training phases. Used for rapid regain after a break within that protocol, not as a universal regain-speed rule or a prescription to take planned layoffs.",
     },
     {
       id: "4",
@@ -269,7 +273,7 @@ export const returnToTrainingArticle: LearnArticle = {
       citation:
         "Hulmi JJ, Halonen EJ, Sharples AP, O'Connell TM, Kuikka L, Lappi VM, Salokas K, Keskitalo S, Varjosalo M, Ahtiainen JP. Human skeletal muscle possesses both reversible proteomic signatures and a retained proteomic memory after repeated resistance training. J Physiol. 2025;603(9):2655-2673.",
       url: "https://doi.org/10.1113/JP288104",
-      note: "Shows that some resistance-training-related protein changes remain elevated after a multi-week training break, while many others reverse and rise again with retraining. Used as mechanistic support for retained training history, not as a consumer guarantee of faster progress.",
+      note: "Shows that some resistance-training-related protein changes remain altered after a multi-week training break, while many others reverse and rise again with retraining. Used as evidence of a retained molecular trace after detraining, not as proof that those protein changes cause faster strength or hypertrophy reacquisition.",
     },
   ],
 };

--- a/content/articles/how-to-return-to-training-after-time-off.ts
+++ b/content/articles/how-to-return-to-training-after-time-off.ts
@@ -12,7 +12,7 @@ export const returnToTrainingArticle: LearnArticle = {
   description:
     "After a training break, treat your old program as useful history rather than today's prescription. Scale load, volume, frequency, and exercise complexity independently, then let the first sessions update the ramp.",
   date: "2026-09-04",
-  dateModified: "2026-09-04", // revised evidence framing same day as publish draft
+  dateModified: "2026-09-04",
   body: [
     {
       type: "p",
@@ -265,7 +265,7 @@ export const returnToTrainingArticle: LearnArticle = {
       citation:
         "Sharples AP, Turner DC. Skeletal muscle memory. Am J Physiol Cell Physiol. 2023;324(6):C1274-C1294.",
       url: "https://doi.org/10.1152/ajpcell.00099.2023",
-      note: "Reviews cellular and epigenetic accounts of skeletal muscle memory and their implications for later retraining. Used to support retained responsiveness after prior training without claiming a universal regain-speed multiplier.",
+      note: "Reviews cellular and epigenetic accounts of skeletal muscle memory and their implications for later retraining. Used for plausible mechanisms of retained training history, not as proof of a universal regain-speed multiplier or a fixed practical effect size.",
     },
     {
       id: "7",

--- a/content/articles/progressive-overload-without-adding-weight.ts
+++ b/content/articles/progressive-overload-without-adding-weight.ts
@@ -231,6 +231,10 @@ export const progressiveOverloadArticle: LearnArticle = {
     },
     {
       type: "p",
+      text: "The same logic applies after a longer layoff. Once early return sessions show that familiar work is tolerable again, ordinary progression resumes: restore quality reps and sets, then load, rather than copying old working weights on day one. That re-entry problem is covered in [how to return to training after time off](/learn/how-to-return-to-training-after-time-off).",
+    },
+    {
+      type: "p",
       text: "IOFitness is being designed around that kind of decision. The programming model is intended to treat progression as evidence-driven parameter change, not as a fixed calendar of heavier weights. The framework in this article still works with a notebook if you keep the comparisons honest.",
     },
 

--- a/content/articles/what-is-adaptive-training.ts
+++ b/content/articles/what-is-adaptive-training.ts
@@ -109,7 +109,7 @@ export const adaptiveTrainingArticle: LearnArticle = {
     { type: "h3", text: "Level 4: Schedule and sequence adaptation" },
     {
       type: "p",
-      text: "The system can reason about a disrupted week. Missed workouts, travel, added sport, or fewer training days change which future sessions are recommended, and in what order, rather than merely sliding calendar labels. This is where [what to do when you miss a workout](/learn/what-to-do-when-you-miss-a-workout) stops being a user improvisation problem and becomes a programming problem [5][6].",
+      text: "The system can reason about a disrupted week. Missed workouts, travel, added sport, or fewer training days change which future sessions are recommended, and in what order, rather than merely sliding calendar labels. This is where [what to do when you miss a workout](/learn/what-to-do-when-you-miss-a-workout) stops being a user improvisation problem and becomes a programming problem [5][6]. A longer layoff raises the same issue at a larger scale: [returning to training after time off](/learn/how-to-return-to-training-after-time-off) means the old plan is still useful history, but current capacity has to be re-estimated from new sessions.",
     },
 
     { type: "h3", text: "Level 5: Program adaptation" },

--- a/content/articles/what-to-do-when-you-miss-a-workout.ts
+++ b/content/articles/what-to-do-when-you-miss-a-workout.ts
@@ -208,7 +208,7 @@ export const missedWorkoutArticle: LearnArticle = {
     { type: "h2", text: "When the miss is several workouts, not one" },
     {
       type: "p",
-      text: "One missed session is usually a local edit. Several missed sessions are a rebuild.",
+      text: "One missed session is usually a local edit. Several missed sessions are a rebuild. If the gap stretches into weeks, the problem becomes [how to return to training after time off](/learn/how-to-return-to-training-after-time-off): the old plan remains useful history, but current capacity and tolerance need to be re-checked before the previous weekly dose returns.",
     },
     {
       type: "p",

--- a/content/learn.ts
+++ b/content/learn.ts
@@ -1,4 +1,5 @@
 import { twoGoalsArticle } from "./articles/how-to-train-for-two-goals-at-once";
+import { returnToTrainingArticle } from "./articles/how-to-return-to-training-after-time-off";
 import { progressiveOverloadArticle } from "./articles/progressive-overload-without-adding-weight";
 import { adaptiveTrainingArticle } from "./articles/what-is-adaptive-training";
 import { missedWorkoutArticle } from "./articles/what-to-do-when-you-miss-a-workout";
@@ -43,6 +44,7 @@ export const learnArticles: LearnArticle[] = [
   twoGoalsArticle,
   adaptiveTrainingArticle,
   progressiveOverloadArticle,
+  returnToTrainingArticle,
 ];
 
 export function getLearnArticles(): LearnArticle[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Authority article #5 for pre-launch SEO/AEO:

- **Title:** How to Return to Training After Time Off
- **Slug:** `/learn/how-to-return-to-training-after-time-off`
- **Thesis:** After time off, the old program is useful history, not today’s prescription. Scale load, volume, frequency, and exercise novelty independently; use the first sessions as evidence before ramping.

## Why this framing

SERP comeback advice often collapses to arbitrary rules (50% weights, half volume, fixed 4-week ramps). This piece treats re-entry as capacity uncertainty: preserve familiar structure, reduce the most uncertain dose variables, and update week two from response.

## Implementation

- New article registry entry (sitemap / metadata / Article JSON-LD via existing Learn system)
- Reciprocal links from adaptive training, progressive overload, and missed-workout articles
- No article-system redesign

## Checks

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build` — pass (route prerendered)

## Not in this PR

- Do not merge until editorial/publish review
- No IndexNow / production publish yet
- Article #6 not started

## Preview

Once deployed from this branch: `https://io.fitness/learn/how-to-return-to-training-after-time-off` (or Vercel preview for the PR).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f25f6092-90b3-45ec-b28a-4cd06a06c850?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f25f6092-90b3-45ec-b28a-4cd06a06c850&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

