### PR TITLE
feat(marketing): show D1 app UI on the homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import { homepageCopy } from "@/content/homepage";
+import { AdaptSheetPreview } from "@/components/app-preview/adapt-sheet";
+import { HomeScreenPreview } from "@/components/app-preview/home-screen";
+import { TimerScreenPreview } from "@/components/app-preview/timer-screen";
+import { ProductPhone } from "@/components/product-phone";
+import { homepageCopy, type ProcessPreviewKind } from "@/content/homepage";
 import { absoluteUrl, siteConfig } from "@/lib/site";
 import type { Metadata } from "next";
 
@@ -26,33 +30,48 @@ const proseSections = [
   homepageCopy.why,
 ] as const;
 
+function ProcessPreview({ kind }: { kind: ProcessPreviewKind }) {
+  if (kind === "adapt") {
+    return <AdaptSheetPreview />;
+  }
+  return <TimerScreenPreview />;
+}
+
 export default function Home() {
   return (
     <main id="main">
       <section className="mx-auto max-w-5xl px-5 pb-16 pt-16 sm:px-8 sm:pb-24 sm:pt-24">
-        <p className="text-sm tracking-[0.18em] text-muted uppercase">
-          {siteConfig.name}
-        </p>
-        <h1 className="mt-5 max-w-3xl font-display text-5xl leading-[1.05] tracking-tight text-ink sm:text-7xl">
-          {homepageCopy.hero.heading}
-        </h1>
-        <p className="mt-8 max-w-2xl text-lg leading-8 text-muted sm:text-xl sm:leading-9">
-          {homepageCopy.hero.product}
-        </p>
-        <p className="mt-10">
-          <a
-            href={homepageCopy.cta.href}
-            className="inline-flex min-h-12 items-center rounded-sm bg-accent px-4 text-base text-paper hover:bg-accent-hover"
-          >
-            {homepageCopy.cta.label}
-          </a>
-        </p>
+        <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_19rem] lg:gap-16">
+          <div>
+            <p className="font-display text-2xl tracking-tight text-ink sm:text-3xl">
+              {siteConfig.name}
+            </p>
+            <h1 className="mt-5 max-w-3xl font-sans text-5xl leading-[1.05] tracking-tight text-ink sm:text-7xl">
+              {homepageCopy.hero.heading}
+            </h1>
+            <p className="mt-8 max-w-2xl text-lg leading-8 text-muted sm:text-xl sm:leading-9">
+              {homepageCopy.hero.product}
+            </p>
+            <p className="mt-10">
+              <a
+                href={homepageCopy.cta.href}
+                className="inline-flex min-h-12 items-center rounded-sm bg-accent px-4 text-base text-paper hover:bg-accent-hover"
+              >
+                {homepageCopy.cta.label}
+              </a>
+            </p>
+          </div>
+
+          <ProductPhone label={homepageCopy.hero.appPreviewLabel}>
+            <HomeScreenPreview />
+          </ProductPhone>
+        </div>
       </section>
 
       {proseSections.map((section) => (
         <section key={section.heading} className="border-t border-rule">
           <div className="mx-auto max-w-5xl px-5 py-14 sm:px-8 sm:py-20">
-            <h2 className="max-w-3xl font-display text-3xl leading-tight tracking-tight sm:text-4xl">
+            <h2 className="max-w-3xl font-sans text-3xl leading-tight tracking-tight sm:text-4xl">
               {section.heading}
             </h2>
             <p className="mt-6 max-w-2xl text-lg leading-8 text-muted">{section.body}</p>
@@ -62,28 +81,52 @@ export default function Home() {
 
       <section className="border-t border-rule">
         <div className="mx-auto max-w-5xl px-5 py-14 sm:px-8 sm:py-20">
-          <h2 className="max-w-3xl font-display text-3xl leading-tight tracking-tight sm:text-4xl">
+          <h2 className="max-w-3xl font-sans text-3xl leading-tight tracking-tight sm:text-4xl">
             {homepageCopy.process.heading}
           </h2>
           <p className="mt-6 max-w-2xl text-lg leading-8 text-muted">
             {homepageCopy.process.body}
           </p>
-          <ul className="mt-10 grid max-w-3xl gap-8">
-            {homepageCopy.process.items.map((item) => (
-              <li key={item.title}>
-                <h3 className="font-display text-xl tracking-tight text-ink sm:text-2xl">
-                  {item.title}
-                </h3>
-                <p className="mt-3 max-w-2xl text-base leading-7 text-muted">{item.body}</p>
-              </li>
-            ))}
+          <ul className="mt-10 grid max-w-5xl gap-10">
+            {homepageCopy.process.items.map((item) => {
+              const preview =
+                "preview" in item ? (item.preview as ProcessPreviewKind) : undefined;
+              const previewLabel =
+                "previewLabel" in item ? item.previewLabel : undefined;
+
+              return (
+                <li
+                  key={item.title}
+                  className={
+                    preview
+                      ? "grid items-start gap-8 lg:grid-cols-[minmax(0,1fr)_15rem]"
+                      : undefined
+                  }
+                >
+                  <div>
+                    <h3 className="font-sans text-xl tracking-tight text-ink sm:text-2xl">
+                      {item.title}
+                    </h3>
+                    <p className="mt-3 max-w-2xl text-base leading-7 text-muted">{item.body}</p>
+                  </div>
+                  {preview ? (
+                    <ProductPhone
+                      label={previewLabel ?? item.title}
+                      className="w-[min(100%,15rem)] sm:w-[15rem]"
+                    >
+                      <ProcessPreview kind={preview} />
+                    </ProductPhone>
+                  ) : null}
+                </li>
+              );
+            })}
           </ul>
         </div>
       </section>
 
       <section className="border-t border-rule">
         <div className="mx-auto max-w-5xl px-5 py-14 sm:px-8 sm:py-20">
-          <h2 className="max-w-3xl font-display text-3xl leading-tight tracking-tight sm:text-4xl">
+          <h2 className="max-w-3xl font-sans text-3xl leading-tight tracking-tight sm:text-4xl">
             {homepageCopy.situations.heading}
           </h2>
           <p className="mt-6 max-w-2xl text-lg leading-8 text-muted">
@@ -93,7 +136,7 @@ export default function Home() {
             {homepageCopy.situations.items.map((item) => (
               <li key={item.href} className="border-t border-rule py-6 sm:pr-8">
                 <Link href={item.href} className="group block">
-                  <h3 className="font-display text-xl tracking-tight text-ink group-hover:text-accent sm:text-2xl">
+                  <h3 className="font-sans text-xl tracking-tight text-ink group-hover:text-accent sm:text-2xl">
                     {item.title}
                   </h3>
                   <p className="mt-3 text-base leading-7 text-muted">{item.body}</p>
@@ -106,7 +149,7 @@ export default function Home() {
 
       <section className="border-t border-rule">
         <div className="mx-auto max-w-5xl px-5 py-14 sm:px-8 sm:py-20">
-          <h2 className="max-w-3xl font-display text-3xl leading-tight tracking-tight sm:text-4xl">
+          <h2 className="max-w-3xl font-sans text-3xl leading-tight tracking-tight sm:text-4xl">
             {homepageCopy.closing.heading}
           </h2>
           <p className="mt-6 max-w-2xl text-lg leading-8 text-muted">

--- a/components/app-preview/adapt-sheet.tsx
+++ b/components/app-preview/adapt-sheet.tsx
@@ -1,0 +1,47 @@
+/**
+ * Marketing plate of Adapt / This hurt — product differentiator vs template apps.
+ */
+export function AdaptSheetPreview() {
+  return (
+    <div className="flex h-full flex-col bg-paper">
+      <div className="flex-1 px-4 pt-3 opacity-40">
+        <p className="text-xs tracking-[0.1em] text-muted uppercase">Set 2 of 3</p>
+        <p className="mt-6 text-center font-sans text-4xl font-semibold text-ink">0:42</p>
+        <p className="mt-2 text-center text-sm font-semibold tracking-wide text-ink">
+          Romanian Deadlift
+        </p>
+      </div>
+
+      <div className="rounded-t-2xl border border-rule border-b-0 bg-field px-4 pb-4 pt-3">
+        <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-rule" aria-hidden="true" />
+        <p className="font-sans text-base font-semibold text-ink">This hurt</p>
+        <p className="mt-1 text-sm leading-5 text-muted">
+          Pick an easier option. We&apos;ll rebuild the next sessions from your choice.
+        </p>
+
+        <div className="mt-3 space-y-2">
+          <div className="rounded-md border border-accent bg-accent/10 px-3 py-2.5">
+            <p className="text-[0.65rem] font-semibold tracking-wide text-accent uppercase">
+              Recommended
+            </p>
+            <p className="mt-0.5 font-sans text-sm font-semibold text-ink">Hip Hinge Hold</p>
+            <p className="text-xs text-muted">Nearest easier hinge in your series</p>
+          </div>
+          <div className="rounded-md border border-rule bg-paper px-3 py-2.5">
+            <p className="font-sans text-sm font-semibold text-ink">Wall Drill</p>
+            <p className="text-xs text-muted">Pattern still intact, less load</p>
+          </div>
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <span className="inline-flex flex-1 items-center justify-center rounded-sm bg-accent px-2 py-2.5 text-center text-sm text-paper">
+            Use this
+          </span>
+          <span className="inline-flex items-center justify-center rounded-sm border border-rule px-3 py-2.5 text-sm text-ink">
+            Keep going
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/app-preview/home-screen.tsx
+++ b/components/app-preview/home-screen.tsx
@@ -1,0 +1,68 @@
+/**
+ * Marketing plate of the D1 home screen — mirrors iofit chrome, not live data.
+ */
+export function HomeScreenPreview() {
+  return (
+    <div className="flex h-full flex-col px-4 pb-3 pt-2">
+      <p className="font-display text-[1.35rem] leading-none text-accent">IOFitness</p>
+      <p className="mt-2 font-sans text-2xl font-semibold tracking-tight text-ink">Hey Jon</p>
+      <p className="mt-1 text-sm leading-5 text-muted">Get better — from wherever you are.</p>
+
+      <div className="mt-4 rounded-md border border-rule bg-field p-4">
+        <p className="text-[0.7rem] font-semibold tracking-[0.12em] text-accent uppercase">
+          Next Up
+        </p>
+        <p className="mt-1 font-sans text-xl font-semibold leading-tight tracking-tight text-ink">
+          Lower Body Strength
+        </p>
+        <p className="mt-1 text-sm text-muted">Week 2 · Workout 3 of 4</p>
+        <div className="mt-3 flex gap-2">
+          <span className="inline-flex flex-1 items-center justify-center rounded-sm bg-accent px-2 py-2.5 text-center text-sm text-paper">
+            Start Workout
+          </span>
+          <span className="inline-flex items-center justify-center rounded-sm border border-rule px-3 py-2.5 text-sm text-ink">
+            Skip
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-md border border-rule bg-field p-3">
+        <p className="font-sans text-sm font-semibold text-ink">Your Activity</p>
+        <div className="mt-2 flex items-center gap-2">
+          <span className="text-xs text-muted">This week</span>
+          <span className="flex flex-1 gap-1.5" aria-hidden="true">
+            <span className="h-2.5 w-2.5 rounded-full bg-accent" />
+            <span className="h-2.5 w-2.5 rounded-full bg-accent" />
+            <span className="h-2.5 w-2.5 rounded-full border border-rule bg-paper" />
+            <span className="h-2.5 w-2.5 rounded-full border border-rule bg-paper" />
+          </span>
+          <span className="text-xs text-muted">2/4</span>
+        </div>
+        <div className="mt-3 flex justify-between border-t border-rule pt-3 text-center">
+          <div className="flex-1">
+            <p className="font-sans text-lg font-semibold text-ink">7</p>
+            <p className="text-[0.65rem] text-muted">last 30 days</p>
+          </div>
+          <div className="w-px bg-rule" />
+          <div className="flex-1">
+            <p className="font-sans text-lg font-semibold text-ink">3</p>
+            <p className="text-[0.65rem] text-muted">week streak</p>
+          </div>
+          <div className="w-px bg-rule" />
+          <div className="flex-1">
+            <p className="font-sans text-sm font-semibold text-ink">Yesterday</p>
+            <p className="text-[0.65rem] text-muted">last workout</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-auto border-t border-rule pt-2">
+        <div className="flex justify-around text-[0.65rem] text-muted">
+          <span className="font-semibold text-accent">Home</span>
+          <span>Exercises</span>
+          <span>Profile</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/app-preview/timer-screen.tsx
+++ b/components/app-preview/timer-screen.tsx
@@ -1,0 +1,40 @@
+/**
+ * Marketing plate of the active workout timer — daily-use surface.
+ */
+export function TimerScreenPreview() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b-2 border-[#3f6b4a] bg-[rgba(63,107,74,0.15)] px-4 py-4 text-center">
+        <div className="flex items-center justify-center gap-3 text-xs font-semibold text-ink">
+          <span>Set 2 of 4</span>
+          <span className="font-normal text-muted">28min left</span>
+        </div>
+        <p className="mt-2 font-sans text-5xl font-semibold leading-none tracking-tight text-ink">
+          0:45
+        </p>
+        <p className="mt-2 font-sans text-base font-semibold tracking-wide text-ink">
+          Front Squat
+        </p>
+      </div>
+
+      <div className="flex-1 space-y-3 px-4 py-4">
+        <div className="rounded-md border border-rule bg-field px-3 py-3">
+          <p className="text-xs text-muted">Weight</p>
+          <p className="mt-0.5 font-sans text-lg font-semibold text-ink">135 lb</p>
+        </div>
+        <div className="rounded-md border border-rule bg-field px-3 py-3">
+          <p className="text-xs text-muted">Reps</p>
+          <p className="mt-0.5 font-sans text-lg font-semibold text-ink">5</p>
+        </div>
+        <div className="mt-auto flex gap-2 pt-6">
+          <span className="inline-flex flex-1 items-center justify-center rounded-sm border border-rule py-2.5 text-sm text-ink">
+            Skip
+          </span>
+          <span className="inline-flex flex-1 items-center justify-center rounded-sm bg-accent py-2.5 text-sm text-paper">
+            Log set
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/product-phone.tsx
+++ b/components/product-phone.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+
+type ProductPhoneProps = {
+  children: ReactNode;
+  /** Accessible name for the preview as a whole */
+  label: string;
+  className?: string;
+};
+
+/**
+ * Quiet matte phone chrome for product UI plates.
+ * No glow, no photography, no floating badges — paper + thin rule only.
+ */
+export function ProductPhone({ children, label, className = "" }: ProductPhoneProps) {
+  return (
+    <figure
+      aria-label={label}
+      className={`mx-auto w-[min(100%,17.5rem)] sm:w-[19rem] ${className}`}
+    >
+      <div className="overflow-hidden rounded-[1.75rem] border border-rule bg-field shadow-none">
+        {/* Status bar */}
+        <div className="flex items-center justify-between px-5 pb-1 pt-3 text-[0.65rem] tracking-wide text-muted">
+          <span>9:41</span>
+          <span className="flex items-center gap-1" aria-hidden="true">
+            <span className="inline-block h-1.5 w-3 rounded-sm bg-muted/50" />
+            <span className="inline-block h-2 w-3 rounded-sm border border-muted/60" />
+          </span>
+        </div>
+        <div className="min-h-[28rem] bg-paper sm:min-h-[30rem]">{children}</div>
+        {/* Home indicator */}
+        <div className="flex justify-center bg-paper pb-2 pt-1" aria-hidden="true">
+          <span className="h-1 w-24 rounded-full bg-rule" />
+        </div>
+      </div>
+    </figure>
+  );
+}

--- a/content/homepage.ts
+++ b/content/homepage.ts
@@ -1,8 +1,18 @@
+export type ProcessPreviewKind = "adapt" | "timer";
+
+export type ProcessItem = {
+  title: string;
+  body: string;
+  preview?: ProcessPreviewKind;
+  previewLabel?: string;
+};
+
 export const homepageCopy = {
   hero: {
     heading: "Get better.",
     product:
       "IOFitness builds adaptive training around your goals, sports, limitations, and how you actually progress — so the plan keeps changing as you get better.",
+    appPreviewLabel: "IOFitness app home — next workout and weekly progress",
   },
   cta: {
     label: "Get the App",
@@ -21,8 +31,8 @@ export const homepageCopy = {
     body: "A single score cannot tell you whether you are becoming more capable. Strength, fitness, athleticism, and the ability to do the things you care about all count, and they count differently for different people.",
   },
   why: {
-    heading: "Why we're building IOFitness",
-    body: "Programming that path is hard to do well on your own. Generic plans do not account for your limitations, the activities you care about, or how you actually progress. We are building IOFitness so the plan can be specific to you, and so it can change when you change.",
+    heading: "Why IOFitness exists",
+    body: "Programming that path is hard to do well on your own. Generic plans do not account for your limitations, the activities you care about, or how you actually progress. IOFitness is built to make the plan specific to you — and to change it when you change.",
   },
   process: {
     heading: "What the plan should decide next",
@@ -39,12 +49,16 @@ export const homepageCopy = {
       {
         title: "Swap the lift, keep the job",
         body: "A tender joint should change the exercise, not pause the whole plan. Progress the substitute from how the next sessions feel.",
+        preview: "adapt",
+        previewLabel: "Adapt — This hurt: pick an easier hinge and keep training",
       },
       {
         title: "Rebuild from current capacity",
         body: "After time off, keep familiar work and reduce uncertain volume until readiness is clear again.",
+        preview: "timer",
+        previewLabel: "Active workout timer — log the work in front of you",
       },
-    ],
+    ] satisfies ProcessItem[],
   },
   situations: {
     heading: "If this is your training week",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a quiet matte phone plate to the homepage hero showing the D1 home screen (wordmark, next workout, week progress).
- Pairs process beats with Adapt (This hurt) and active-timer previews so the site proves the product, not only the editorial thesis.
- Live CSS product UI using D1 tokens (no photography, no AI mockups, no glow). CTA remains Get the App → `#` until a real store URL exists.

## Test plan
- [ ] Desktop: hero reads as one composition (brand + Get better. + sentence + CTA + phone).
- [ ] Mobile: phone stacks under copy; no overflow / clipped text.
- [ ] Process: Adapt + timer plates render beside the matching beats.
- [ ] Visual: paper/forest, Fraunces wordmark only, no purple/glow/card collage in hero.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cccdd12-a7fc-40b5-83d6-ec1b1716c123?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cccdd12-a7fc-40b5-83d6-ec1b1716c123&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

